### PR TITLE
Change to composer installed Slim, xdebug fixes, and remove hard coded path

### DIFF
--- a/config_api.php
+++ b/config_api.php
@@ -1,0 +1,4 @@
+<?php
+
+define('FA_ROOT', realpath('../..'));
+define('API_ROOT', realpath('.'));

--- a/index.php
+++ b/index.php
@@ -15,21 +15,23 @@ Free software under GNU GPL
 
 ini_set('html_errors', false);
 ini_set('xdebug.show_exception_trace', 0);
+// ini_set('xdebug.auto_trace', 2);
+
+include_once('config_api.php');
 
 global $security_areas, $security_groups, $security_headings, $path_to_root, $db, $db_connections;
 
-$path_to_root = "../..";
-
 $page_security = 'SA_API';
-ini_set('xdebug.auto_trace', 2);
-include_once ($path_to_root . "/modules/api/session-custom.inc");
-include_once ($path_to_root . "/modules/api/vendor/autoload.php");
+
+include_once (API_ROOT . "/session-custom.inc");
+include_once (API_ROOT . "/vendor/autoload.php");
+
 \Slim\Slim::registerAutoloader();
 
-include_once ($path_to_root . "/modules/api/util.php");
+include_once (API_ROOT . "/util.php");
 
-include_once($path_to_root . "/includes/date_functions.inc");
-include_once($path_to_root . "/includes/data_checks.inc");
+include_once(FA_ROOT . "/includes/date_functions.inc");
+include_once(FA_ROOT . "/includes/data_checks.inc");
 
 // echo "sales quote => ".ST_SALESQUOTE;
 // echo "sales order => ".ST_SALESORDER;
@@ -56,8 +58,8 @@ define("RESULTS_PER_PAGE", 2);
 // Get Items
 $rest->get('/inventory/', function() use ($rest){
 	
-	global $path_to_root, $req;
-	include_once ($path_to_root . "/modules/api/inventory.inc");
+	global $req;
+	include_once (API_ROOT . "/inventory.inc");
 
 	$page	= $req->get("page");
 
@@ -72,32 +74,25 @@ $rest->get('/inventory/', function() use ($rest){
 // Get Specific Item by Stock Id
 $rest->get('/inventory/:id', function($id) use ($rest) {
 	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/inventory.inc");
+	include_once (API_ROOT . "/inventory.inc");
 	inventory_get($id);
 
 });
 // Add Item
 $rest->post('/inventory/', function() use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/inventory.inc");
+	include_once (API_ROOT . "/inventory.inc");
 	inventory_add();
 	
 });
 // Edit Specific Item
 $rest->put('/inventory/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/inventory.inc");
+	include_once (API_ROOT . "/inventory.inc");
 	inventory_edit($id);
 	
 });
 // Delete Specific Item
 $rest->delete('/inventory/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/inventory.inc");
+	include_once (API_ROOT . "/inventory.inc");
 	inventory_delete($id);
 	
 });
@@ -106,9 +101,7 @@ $rest->delete('/inventory/:id', function($id) use ($rest){
 // ------------------------------- Inventory Movements -------------------------------
 // Get Inventory Movement Types
 $rest->get('/movementtypes/', function() use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/inventory.inc");
+	include_once (API_ROOT . "/inventory.inc");
 	inventory_movementstype_all();
 	
 });
@@ -117,18 +110,14 @@ $rest->get('/movementtypes/', function() use ($rest){
 // ------------------------------- Inventory Locations -------------------------------
 // Get Locations
 $rest->get('/locations/', function() use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/inventory.inc");
+	include_once (API_ROOT . "/inventory.inc");
 	inventory_locations_all();
 	
 });
 
 // Add Location, added by Richard Vinke
 $rest->post('/locations/', function() use ($rest){
-
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/inventory.inc");
+	include_once (API_ROOT . "/inventory.inc");
 	inventory_location_add();
 
 });
@@ -137,9 +126,7 @@ $rest->post('/locations/', function() use ($rest){
 // ------------------------------- Stock Adjustments -------------------------------
 // Add Stock Adjustment
 $rest->post('/stock/', function() use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/inventory.inc");
+	include_once (API_ROOT . "/inventory.inc");
 	stock_adjustment_add();
 	
 });
@@ -148,9 +135,8 @@ $rest->post('/stock/', function() use ($rest){
 // ------------------------------- Item Categories -------------------------------
 // Get Items Categories
 $rest->get('/category/', function() use ($rest){
-	
-	global $path_to_root, $req;
-	include_once ($path_to_root . "/modules/api/category.inc");
+	global $req;
+	include_once (API_ROOT . "/category.inc");
 
 	$page	= $req->get("page");
 
@@ -164,33 +150,25 @@ $rest->get('/category/', function() use ($rest){
 });
 // Get Specific Item Category
 $rest->get('/category/:id', function($id) use ($rest) {
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/category.inc");
+	include_once (API_ROOT . "/category.inc");
 	category_get($id);
 
 });
 // Add Item Category
 $rest->post('/category/', function() use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/category.inc");
+	include_once (API_ROOT . "/category.inc");
 	category_add();
 	
 });
 // Edit Item Category
 $rest->put('/category/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/category.inc");
+	include_once (API_ROOT . "/category.inc");
 	category_edit($id);
 	
 });
 // Delete Item Category
 $rest->delete('/category/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/category.inc");
+	include_once (API_ROOT . "/category.inc");
 	category_delete($id);
 	
 });
@@ -200,9 +178,8 @@ $rest->delete('/category/:id', function($id) use ($rest){
 // Tax Types
 // Get All Item Tax Types
 $rest->get('/taxtypes/', function() use ($rest){
-	
-	global $path_to_root, $req;
-	include_once ($path_to_root . "/modules/api/taxtypes.inc");
+	global $req;
+	include_once (API_ROOT . "/taxtypes.inc");
 
 	$page	= $req->get("page");
 
@@ -220,9 +197,8 @@ $rest->get('/taxtypes/', function() use ($rest){
 // Tax Groups
 // Get All Tax Groups
 $rest->get('/taxgroups/', function() use ($rest){
-	
-	global $path_to_root, $req;
-	include_once ($path_to_root . "/modules/api/taxgroups.inc");
+	global $req;
+	include_once (API_ROOT . "/taxgroups.inc");
 
 	$page	= $req->get("page");
 
@@ -240,17 +216,14 @@ $rest->get('/taxgroups/', function() use ($rest){
 // Customers
 // Get Customer General Info
 $rest->get('/customers/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/customers.inc");
+	include_once (API_ROOT . "/customers.inc");
 	customer_get($id);
 	
 });
 // All Customers
 $rest->get('/customers/', function() use ($rest){
-	
-	global $path_to_root, $req;
-	include_once ($path_to_root . "/modules/api/customers.inc");
+	global $req;
+	include_once (API_ROOT . "/customers.inc");
 
 	$page	= $req->get("page");
 
@@ -264,33 +237,25 @@ $rest->get('/customers/', function() use ($rest){
 });
 // Add Customer
 $rest->post('/customers/', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/customers.inc");
+	include_once (API_ROOT . "/customers.inc");
 	customer_add();
 	
 });
 // Edit Customer
 $rest->put('/customers/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/customers.inc");
+	include_once (API_ROOT . "/customers.inc");
 	customer_edit($id);
 	
 });
 // Delete Customer
 $rest->delete('/customers/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/suppliers.inc");
+	include_once (API_ROOT . "/suppliers.inc");
 	customer_delete($id);
 	
 });
 // Get Customer Branches
 $rest->get('/customers/:id/branches/', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/customers.inc");
+	include_once (API_ROOT . "/customers.inc");
 	customer_branches_get($id);
 	
 });
@@ -300,41 +265,31 @@ $rest->get('/customers/:id/branches/', function($id) use ($rest){
 // Suppliers
 // Get Supplier General Info
 $rest->get('/suppliers/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/suppliers.inc");
+	include_once (API_ROOT . "/suppliers.inc");
 	supplier_get($id);
 	
 });
 // Add Supplier
 $rest->post('/suppliers/', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/suppliers.inc");
+	include_once (API_ROOT . "/suppliers.inc");
 	supplier_add();
 	
 });
 // Edit Supplier
 $rest->put('/suppliers/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/suppliers.inc");
+	include_once (API_ROOT . "/suppliers.inc");
 	supplier_edit($id);
 	
 });
 // Delete Supplier
 $rest->delete('/suppliers/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/suppliers.inc");
+	include_once (API_ROOT . "/suppliers.inc");
 	supplier_delete($id);
 	
 });
 // Get Supplier Contacts
 $rest->get('/suppliers/:id/contacts/', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/suppliers.inc");
+	include_once (API_ROOT . "/suppliers.inc");
 	supplier_contacts_get($id);
 	
 });
@@ -344,9 +299,8 @@ $rest->get('/suppliers/:id/contacts/', function($id) use ($rest){
 // Bank Accounts
 // Get All Bank Accounts
 $rest->get('/bankaccounts/', function() use ($rest){
-	
-	global $path_to_root, $req;
-	include_once ($path_to_root . "/modules/api/bankaccounts.inc");
+	global $req;
+	include_once (API_ROOT . "/bankaccounts.inc");
 
 	$page	= $req->get("page");
 
@@ -360,9 +314,7 @@ $rest->get('/bankaccounts/', function() use ($rest){
 });
 // Get Specific Bank Account
 $rest->get('/bankaccounts/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/bankaccounts.inc");
+	include_once (API_ROOT . "/bankaccounts.inc");
 	bankaccounts_get($id);
 	
 });
@@ -372,9 +324,8 @@ $rest->get('/bankaccounts/:id', function($id) use ($rest){
 // GL Accounts
 // Get GL Accounts
 $rest->get('/glaccounts/', function() use ($rest){
-	
-	global $path_to_root, $req;
-	include_once ($path_to_root . "/modules/api/glaccounts.inc");
+	global $req;
+	include_once (API_ROOT . "/glaccounts.inc");
 
 	$page	= $req->get("page");
 
@@ -388,17 +339,13 @@ $rest->get('/glaccounts/', function() use ($rest){
 });
 // Get Specific GL Account
 $rest->get('/glaccounts/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/glaccounts.inc");
+	include_once (API_ROOT . "/glaccounts.inc");
 	glaccounts_get($id);
 	
 });
 // Get GL Account Types
 $rest->get('/glaccounttypes/', function() use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/glaccounts.inc");
+	include_once (API_ROOT . "/glaccounts.inc");
 	glaccounttypes_all();
 	
 });
@@ -408,9 +355,8 @@ $rest->get('/glaccounttypes/', function() use ($rest){
 // Currencies
 // Get All Currencies
 $rest->get('/currencies/', function() use ($rest){
-	
-	global $path_to_root, $req;
-	include_once ($path_to_root . "/modules/api/currencies.inc");
+	global $req;
+	include_once (API_ROOT . "/currencies.inc");
 
 	$page	= $req->get("page");
 
@@ -424,17 +370,13 @@ $rest->get('/currencies/', function() use ($rest){
 });
 // Get Specific Currency
 $rest->get('/currencies/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/currencies.inc");
+	include_once (API_ROOT . "/currencies.inc");
 	currencies_get($id);
 	
 });
 // Get Last Exchange Rate
 $rest->get('/exrates/:curr_abrev', function($curr_abrev) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/currencies.inc");
+	include_once (API_ROOT . "/currencies.inc");
 	currencies_last_exrate($curr_abrev);
 	
 });
@@ -444,17 +386,13 @@ $rest->get('/exrates/:curr_abrev', function($curr_abrev) use ($rest){
 // Inventory Costs
 // Get Item Cots
 $rest->get('/itemcosts/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/items.inc");
+	include_once (API_ROOT . "/items.inc");
 	itemcosts_get($id);
 	
 });
 // Update Item Cost
 $rest->put('/itemcosts/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/items.inc");
+	include_once (API_ROOT . "/items.inc");
 	itemcosts_update($id);
 	
 });
@@ -464,24 +402,20 @@ $rest->put('/itemcosts/:id', function($id) use ($rest){
 // Fixed Assets
 // Get Fixed Asset
 $rest->get('/assets/:id', function($id) use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/assets.inc");
+	include_once (API_ROOT . "/assets.inc");
 	assets_get($id);
 	
 });
 // Insert Fixed Asset
 $rest->post('/assets/', function() use ($rest){
-	
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/assets.inc");
+	include_once (API_ROOT . "/assets.inc");
 	assets_add();
 	
 });
 // Get Asset Types
 $rest->get('/assettypes/', function() use ($rest){
-	global $path_to_root, $req;
-	include_once ($path_to_root . "/modules/api/assets.inc");
+	global $req;
+	include_once (API_ROOT . "/assets.inc");
 
 	$page	= $req->get("page");
 
@@ -499,34 +433,30 @@ $rest->get('/assettypes/', function() use ($rest){
 // Sales
 // Get Sales Header and Details
 $rest->get('/sales/:trans_no/:trans_type', function($trans_no, $trans_type) use ($rest){
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/sales.inc");
+	include_once (API_ROOT . "/sales.inc");
 	sales_get($trans_no, $trans_type);
 });
 // Insert Sales
 $rest->post('/sales/', function() use ($rest){
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/sales.inc");
+	include_once (API_ROOT . "/sales.inc");
 	sales_add();
 	
 });
 // Edit Sales
 $rest->put('/sales/:trans_no/:trans_type', function($trans_no, $trans_type) use ($rest){
-	global $path_to_root;
-	include_once ($path_to_root . "/modules/api/sales.inc");
+	include_once (API_ROOT . "/sales.inc");
 	sales_edit($trans_no, $trans_type);
 	
 });
 // Cancel Sales
 $rest->delete('/sales/:branch_id/:uuid', function($branch_id, $uuid) use ($rest) {
-	global $path_to_root;
-	include_once($path_to_root . "/modules/api/sales.inc");
+	include_once(API_ROOT . "/sales.inc");
 	sales_cancel($branch_id, $uuid);
 });
 // All Sales
 $rest->get('/sales/:trans_type/', function($trans_type) use ($rest){
-	global $path_to_root, $req;
-	include_once ($path_to_root . "/modules/api/sales.inc");
+	global $req;
+	include_once (API_ROOT . "/sales.inc");
 
 	$page	= $req->get("page");
 


### PR DESCRIPTION
I've changed to use a composer installed Slim rather than the one in the repo, some fixes for xdebug users and removed the hard coded path (which admittedly doesn't conform to the pattern set by FA).

I'm planning on making additional changes as follows:
- pull out the routes into separate files, one per group.
- add more api methods

Let me know if you're wanting PRs to this project.
