### PR TITLE
Refactor tests to ensure consistency in POST and PUT api

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
 services:
   - mysql
 before_script:
+  - echo 'always_populate_raw_post_data = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # get the latest frontaccounting code
   - git clone -b master https://github.com/FrontAccountingERP/FA.git _frontaccounting
   # composer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+#### 27 November 2017
+
+- Refactor tests to ensure consistency in POST and PUT api.
+  Added tests/Crud_Base.php
+- Add api_ensureAssociateArray to remove the numeric index elements that come from the Front Accounting functions.
+- The category end point now follows the database schema more closely for property names.
+- The customers end point now follows the database schema more closely for property names.
+
 #### 23 November 2017
 
 - Added support for requests sent using Content-Type: application/json
@@ -27,22 +35,23 @@ Thanks to Salman Sarwar
 - Bug Fix in inventory.inc
 
 #### 14 July 2013:
-- Added .htaccess so you can now use API URL's without index.php, examples: (Thanks to Christian Estrella)
-	OLD: GET http://mysystem.com/api/index.php/locations/
-	NEW: GET http://mysystem.com/api/locations/
+- Added .htaccess so you can now use API URL's without index.php, examples:
+  (Thanks to Christian Estrella)
+    OLD: GET http://mysystem.com/api/index.php/locations/
+    NEW: GET http://mysystem.com/api/locations/
 
 - Added Pagination to GET methods, it used to return all entries, now is per page, under index.php it has define("RESULTS_PER_PAGE", 2); that defines how many entries you will get per page, if you dont establish a page on the request you will get the first page. (Thanks to Christian Estrella)
-	OLD Request: GET http://mysystem.com/api/index.php/locations/
-	OLD Response: ALL LOCATIONS
-	
-	NEW Request 1: GET http://mysystem.com/api/index.php/locations/
-	NEW Response 1: First Page of Locations
-	
-	NEW Request 2: GET http://mysystem.com/api/index.php/locations/?page=5
-	NEW Response 2: Page 5 of Locations
+    OLD Request: GET http://mysystem.com/api/index.php/locations/
+    OLD Response: ALL LOCATIONS
+    
+    NEW Request 1: GET http://mysystem.com/api/index.php/locations/
+    NEW Response 1: First Page of Locations
+    
+    NEW Request 2: GET http://mysystem.com/api/index.php/locations/?page=5
+    NEW Response 2: Page 5 of Locations
 
 - Added Sales Transactions Methods for Quotes, Sales Orders, Deliveries, Invoices (GET, PUT, POST)
-	NOTE: This changes hasn't been tested deeply, might have some bugs
+    NOTE: This changes hasn't been tested deeply, might have some bugs
 
 #### 14 June 2013:
 - Added POST /locations/ To Add A Location Thanks to Richard Vinke

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,7 +96,7 @@ gulp.task('package-zip', ['package-vendor'], function(cb) {
     src: "./",
     name: "frontaccounting",
     version: "2.4",
-    release: "-api.module.1.3"
+    release: "-api.module.1.4"
   };
   execute(
     'rm -f *.zip && cd <%= src %> && zip -r -x@./upload-exclude-zip.txt -y -q ./<%= name %>-<%= version %><%= release %>.zip .',
@@ -112,7 +112,7 @@ gulp.task('package-tar', ['package-vendor'], function(cb) {
     src: "./",
     name: "frontaccounting",
     version: "2.4",
-    release: "-api.module.1.3"
+    release: "-api.module.1.4"
   };
   execute(
     'rm -f *.tgz && cd <%= src %> && tar -cvzf ./<%= name %>-<%= version %><%= release %>.tgz -X upload-exclude.txt * .htaccess',

--- a/src/BankAccounts.php
+++ b/src/BankAccounts.php
@@ -27,9 +27,7 @@ class BankAccounts
 	public function getById($rest, $id)
 	{
 		$bank = get_bank_account($id);
-		if (! $bank)
-			$bank = array();
-		api_success_response(json_encode($bank));
+		api_success_response(json_encode(\api_ensureAssociativeArray($bank)));
 	}
 
 	private function bankaccounts_all($from = null)

--- a/src/Category.php
+++ b/src/Category.php
@@ -27,9 +27,9 @@ class Category
 	public function getById($rest, $id)
 	{
 		$catego = get_item_category($id);
-		if(!$catego) $catego = array();
-		api_success_response(json_encode($catego));
+		api_success_response(json_encode(api_ensureAssociativeArray($catego)));
 	}
+
 	// Add Item
 	public function post($rest)
 	{
@@ -40,29 +40,29 @@ class Category
 		if(!isset($info['description'])){
 			api_error(412, 'Description is required');
 		}
-		if(!isset($info['tax_type_id'])){
+		if(!isset($info['dflt_tax_type'])){
 			api_error(412, 'Tax Type is required');
 		}
-		if(!isset($info['units'])){
+		if(!isset($info['dflt_units'])){
 			api_error(412, 'Units is required');
 		}
-		if(!isset($info['mb_flag'])){
+		if(!isset($info['dflt_mb_flag'])){
 			api_error(412, 'MB Flag is required');
 		}
-		if(!isset($info['sales_account'])){
+		if(!isset($info['dflt_sales_act'])){
 			api_error(412, 'Sales Account is required');
 		}
-		if(!isset($info['cogs_account'])){
+		if(!isset($info['dflt_cogs_act'])){
 			api_error(412, 'Cogs Account is required');
 		}
-		if(!isset($info['adjustment_account'])){
+		if(!isset($info['dflt_inventory_act'])){
+			api_error(412, 'Inventory Account is required');
+		}
+		if(!isset($info['dflt_adjustment_act'])){
 			api_error(412, 'Adjustment Account is required');
 		}
-		if(!isset($info['wip_account'])){
+		if(!isset($info['dflt_wip_act'])){
 			api_error(412, 'WIP Account is required');
-		}
-		if(!isset($info['inventory_account'])){
-			api_error(412, 'Inventory Account is required');
 		}
 
 		/*
@@ -70,14 +70,14 @@ class Category
 		$cogs_account, $inventory_account, $adjustment_account, $wip_account,
 		$units, $mb_flag, $dim1, $dim2, $no_sale
 		*/
-		add_item_category($info['description'], $info['tax_type_id'],
-			$info['sales_account'],
-			$info['cogs_account'],
-			$info['inventory_account'],
-			$info['adjustment_account'],
-			$info['wip_account'],
-			$info['units'],
-			$info['mb_flag'],
+		add_item_category($info['description'], $info['dflt_tax_type'],
+			$info['dflt_sales_act'],
+			$info['dflt_cogs_act'],
+			$info['dflt_inventory_act'],
+			$info['dflt_adjustment_act'],
+			$info['dflt_wip_act'],
+			$info['dflt_units'],
+			$info['dflt_mb_flag'],
 			0, // dimension 1
 			0, // dimension2
 			0, // no sale
@@ -108,29 +108,29 @@ class Category
 		if(!isset($info['description'])){
 			api_error(412, 'Description is required');
 		}
-		if(!isset($info['tax_type_id'])){
+		if(!isset($info['dflt_tax_type'])){
 			api_error(412, 'Tax Type is required');
 		}
-		if(!isset($info['units'])){
+		if(!isset($info['dflt_units'])){
 			api_error(412, 'Units is required');
 		}
-		if(!isset($info['mb_flag'])){
+		if(!isset($info['dflt_mb_flag'])){
 			api_error(412, 'MB Flag is required');
 		}
-		if(!isset($info['sales_account'])){
+		if(!isset($info['dflt_sales_act'])){
 			api_error(412, 'Sales Account is required');
 		}
-		if(!isset($info['cogs_account'])){
+		if(!isset($info['dflt_cogs_act'])){
 			api_error(412, 'Cogs Account is required');
 		}
-		if(!isset($info['adjustment_account'])){
+		if(!isset($info['dflt_inventory_act'])){
+			api_error(412, 'Inventory Account is required');
+		}
+		if(!isset($info['dflt_adjustment_act'])){
 			api_error(412, 'Adjustment Account is required');
 		}
-		if(!isset($info['wip_account'])){
+		if(!isset($info['dflt_wip_act'])){
 			api_error(412, 'Assembly Account is required');
-		}
-		if(!isset($info['inventory_account'])){
-			api_error(412, 'Inventory Account is required');
 		}
 
 		/*
@@ -138,14 +138,16 @@ class Category
 		$sales_account, $cogs_account, $inventory_account, $adjustment_account,
 		$wip_account, $units, $mb_flag, $dim1, $dim2, $no_sale
 		*/
-		update_item_category($id, $info['description'], $info['tax_type_id'],
-			$info['sales_account'],
-			$info['cogs_account'],
-			$info['inventory_account'],
-			$info['adjustment_account'],
-			$info['wip_account'],
-			$info['units'],
-			$info['mb_flag'],
+		update_item_category(
+			$id, $info['description'],
+			$info['dflt_tax_type'],
+			$info['dflt_sales_act'],
+			$info['dflt_cogs_act'],
+			$info['dflt_inventory_act'],
+			$info['dflt_adjustment_act'],
+			$info['dflt_wip_act'],
+			$info['dflt_units'],
+			$info['dflt_mb_flag'],
 			0, // dimension 1
 			0, // dimension2
 			0, // no sale

--- a/src/Customers.php
+++ b/src/Customers.php
@@ -28,9 +28,7 @@ class Customers
 	public function getById($rest, $id)
 	{
 		$cust = get_customer($id);
-		if (! $cust)
-			$cust = array();
-		api_success_response(json_encode($cust));
+		api_success_response(json_encode(api_ensureAssociativeArray($cust)));
 	}
 	// Add Item
 	public function post($rest)
@@ -39,11 +37,11 @@ class Customers
 		$info = $req->post();
 
 		// Validate Required Fields
-		if (! isset($info['custname'])) {
-			api_error(412, 'Customer Name is required [custname]');
+		if (! isset($info['name'])) {
+			api_error(412, 'Customer Name is required [name]');
 		}
-		if (! isset($info['cust_ref'])) {
-			api_error(412, 'Customer Reference is required [cust_ref]');
+		if (! isset($info['debtor_ref'])) {
+			api_error(412, 'Customer Reference is required [debtor_ref]');
 		}
 		if (! isset($info['address'])) {
 			api_error(412, 'Address is required [address]');
@@ -110,19 +108,19 @@ class Customers
 		}
 
 		/*
-		 * $CustName, $cust_ref, $address, $tax_id, $curr_code, $dimension_id, $dimension2_id, $credit_status,
+		 * $CustName, $debtor_ref, $address, $tax_id, $curr_code, $dimension_id, $dimension2_id, $credit_status,
 		 * $payment_terms, $discount, $pymt_discount, $credit_limit, $sales_type, $notes
 		 */
-		add_customer($info['custname'], $info['cust_ref'], $info['address'], $info['tax_id'], $info['curr_code'], 0, 0, $info['credit_status'], $info['payment_terms'], $info['discount'], $info['pymt_discount'], $info['credit_limit'], $info['sales_type'], $info['notes']);
+		add_customer($info['name'], $info['debtor_ref'], $info['address'], $info['tax_id'], $info['curr_code'], 0, 0, $info['credit_status'], $info['payment_terms'], $info['discount'], $info['pymt_discount'], $info['credit_limit'], $info['sales_type'], $info['notes']);
 
 		$selected_id = db_insert_id();
 		$auto_create_branch = 1;
 		if (isset($auto_create_branch) && $auto_create_branch == 1) {
-			add_branch($selected_id, $info['custname'], $info['cust_ref'], $info['address'], $info['salesman'], $info['area'], $info['tax_group_id'], '1', get_company_pref('default_sales_discount_act'), get_company_pref('debtors_act'), get_company_pref('default_prompt_payment_act'), $info['location'], $info['address'], 0, 0, $info['ship_via'], $info['notes']);
+			add_branch($selected_id, $info['name'], $info['debtor_ref'], $info['address'], $info['salesman'], $info['area'], $info['tax_group_id'], '1', get_company_pref('default_sales_discount_act'), get_company_pref('debtors_act'), get_company_pref('default_prompt_payment_act'), $info['location'], $info['address'], 0, 0, $info['ship_via'], $info['notes']);
 
 			$selected_branch = db_insert_id();
 
-			add_crm_person($info['cust_ref'], $info['custname'], '', $info['address'], $info['phone'], $info['phone2'], $info['fax'], $info['email'], '', '');
+			add_crm_person($info['debtor_ref'], $info['name'], '', $info['address'], $info['phone'], $info['phone2'], $info['fax'], $info['email'], '', '');
 
 			$pers_id = db_insert_id();
 			add_crm_contact('cust_branch', 'general', $selected_branch, $pers_id);
@@ -148,11 +146,11 @@ class Customers
 		}
 
 		// Validate Required Fields
-		if (! isset($info['custname'])) {
-			api_error(412, 'Customer Name is required [custname]');
+		if (! isset($info['name'])) {
+			api_error(412, 'Customer Name is required [name]');
 		}
-		if (! isset($info['cust_ref'])) {
-			api_error(412, 'Customer Reference is required [cust_ref]');
+		if (! isset($info['debtor_ref'])) {
+			api_error(412, 'Customer Reference is required [debtor_ref]');
 		}
 		if (! isset($info['address'])) {
 			api_error(412, 'Address is required [address]');
@@ -190,10 +188,10 @@ class Customers
 		}
 
 		/*
-		 * $customer_id, $CustName, $cust_ref, $address, $tax_id, $curr_code, $dimension_id, $dimension2_id,
+		 * $customer_id, $CustName, $debtor_ref, $address, $tax_id, $curr_code, $dimension_id, $dimension2_id,
 		 * $credit_status, $payment_terms, $discount, $pymt_discount, $credit_limit, $sales_type, $notes
 		 */
-		update_customer($id, $info['custname'], $info['cust_ref'], $info['address'], $info['tax_id'], $info['curr_code'], 0, 0, $info['credit_status'], $info['payment_terms'], $info['discount'], $info['pymt_discount'], $info['credit_limit'], $info['sales_type'], $info['notes']);
+		update_customer($id, $info['name'], $info['debtor_ref'], $info['address'], $info['tax_id'], $info['curr_code'], 0, 0, $info['credit_status'], $info['payment_terms'], $info['discount'], $info['pymt_discount'], $info['credit_limit'], $info['sales_type'], $info['notes']);
 
 		api_success_response("Customer has been updated");
 	}

--- a/src/GLAccounts.php
+++ b/src/GLAccounts.php
@@ -28,9 +28,7 @@ class GLAccounts
 	public function getById($rest, $id)
 	{
 		$acct = get_gl_account($id);
-		if (! $acct)
-			$acct = array();
-		api_success_response(json_encode($acct));
+		api_success_response(json_encode(\api_ensureAssociativeArray($acct)));
 	}
 
 	public function getTypes($rest)

--- a/src/Inventory.php
+++ b/src/Inventory.php
@@ -92,9 +92,7 @@ class Inventory
 	function inventory_get($id)
 	{
 		$item = get_item($id);
-		if (! $item)
-			$item = array();
-		api_success_response(json_encode($item));
+		api_success_response(json_encode(api_ensureAssociativeArray($item)));
 	}
 
 	function inventory_add()

--- a/src/Suppliers.php
+++ b/src/Suppliers.php
@@ -21,10 +21,9 @@ class Suppliers
 	public function getById($rest, $id)
 	{
 		$sup = get_supplier($id);
-		if (! $sup)
-			$sup = array();
-		api_success_response(json_encode($sup));
+		api_success_response(json_encode(api_ensureAssociativeArray($sup)));
 	}
+
 	// Add Item
 	public function post($rest)
 	{

--- a/tests/BankAccounts_Test.php
+++ b/tests/BankAccounts_Test.php
@@ -72,20 +72,6 @@ class BankAccountsTest extends PHPUnit_Framework_TestCase
 		$expected->ending_reconcile_balance = '0';
 		$expected->inactive = '0';
 
-		$expected->{ '0' } = '1060';
-		$expected->{ '1' } = '0';
-		$expected->{ '2' } = 'Current account';
-		$expected->{ '3' } = 'N/A';
-		$expected->{ '4' } = 'N/A';
-		$expected->{ '5' } = '';
-		$expected->{ '6' } = 'USD';
-		$expected->{ '7' } = '1';
-		$expected->{ '8' } = '1';
-		$expected->{ '9' } = '5690';
-		$expected->{ '10' } = '0000-00-00 00:00:00';
-		$expected->{ '11' } = '0';
-		$expected->{ '12' } = '0';
-
 		$this->assertEquals($expected, $result);
 	}
 }

--- a/tests/Category_Test.php
+++ b/tests/Category_Test.php
@@ -5,121 +5,68 @@ use GuzzleHttp\Client;
 require_once(__DIR__ . '/TestConfig.php');
 
 require_once(TEST_PATH . '/TestEnvironment.php');
+require_once(TEST_PATH . '/Crud_Base.php');
 
-class CategoryTest extends PHPUnit_Framework_TestCase
+const CATEGORY_DATA = array(
+	'description' => 'description',
+	'dflt_tax_type' => '1',
+	'dflt_units' => 'each',
+	'dflt_mb_flag' => 'D',
+	'dflt_sales_act' => '4010',
+	'dflt_cogs_act' => '5010',
+	'dflt_inventory_act' => '1510',
+	'dflt_adjustment_act' => '5040',
+	'dflt_wip_act' => '1530',
+	'dflt_dim1' => '0',
+	'dflt_dim2' => '0',
+	'inactive' => '0',
+	'dflt_no_sale' => '0',
+	'dflt_no_purchase' => '0',
+);
+
+class CategoryTest extends Crud_Base
 {
+	private $postData = CATEGORY_DATA;
 
-	public function testCRUD_Ok()
+	private $putData;
+
+	public function __construct()
 	{
-		$client = TestEnvironment::client();
+		$this->putData = $this->postData;
+		$this->putData['description'] = 'other description';
 
-		// List
-		$response = $client->get('/modules/api/category/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count0 = count($result);
-		$this->assertGreaterThan(1, $count0);
-
-		// Add
-		$response = $client->post('/modules/api/category/', array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'description' => 'description',
-				'tax_type_id' => '1',
-				'units' => 'each',
-				'mb_flag' => 'D',
-				'sales_account' => '4010',
-				'cogs_account' => '5010',
-				'adjustment_account' => '5040',
-				'wip_account' => '1530',
-				'inventory_account' => '1510',
-			)
-		));
-		$this->assertEquals('201', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-		$id = $result->category_id;
-
-		$this->assertNotNull($id);
-
-		// List again
-		$response = $client->get('/modules/api/category/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
-
-		// Get by id
-		$response = $client->get('/modules/api/category/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-		$this->assertEquals($id, $result->category_id);
-
-		// Write back
-		$response = $client->put('/modules/api/category/' . $id, array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'description' => 'other description',
-				'tax_type_id' => '1',
-				'units' => 'month',
-				'mb_flag' => 'D',
-				'sales_account' => '4010',
-				'cogs_account' => '5010',
-				'adjustment_account' => '5040',
-				'wip_account' => '1530',
-				'inventory_account' => '1510',
-			)
-		));
-
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		// List again
-		$response = $client->get('/modules/api/category/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
-
-		$this->assertEquals($id, $result[$count1 - 1]->category_id);
-		$this->assertEquals('other description', $result[$count1 - 1]->description);
-
-		// Delete
-		$response = $client->delete('/modules/api/category/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		// List again
-		$response = $client->get('/modules/api/category/', array(
-			'headers' => TestEnvironment::headers()
-		));
-
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count2 = count($result);
-		$this->assertEquals($count0, $count2);
-
+		parent::__construct(
+			'/modules/api/category/',
+			'category_id',
+			$this->postData,
+			$this->putData
+		);
 	}
+
+	// 	public function testCRUD_Ok();
+
+}
+
+class CategoryJsonTest extends Crud_Base
+{
+	private $postData = CATEGORY_DATA;
+
+	private $putData;
+
+	public function __construct()
+	{
+		$this->putData = $this->postData;
+		$this->putData['description'] = 'other description';
+
+		parent::__construct(
+			'/modules/api/category/',
+			'category_id',
+			$this->postData,
+			$this->putData
+		);
+		$this->method = Crud_Base::JSON;
+	}
+
+	// 	public function testCRUD_Ok();
 
 }

--- a/tests/Crud_Base.php
+++ b/tests/Crud_Base.php
@@ -1,0 +1,179 @@
+<?php
+
+use GuzzleHttp\Client;
+
+require_once(__DIR__ . '/TestConfig.php');
+
+require_once(TEST_PATH . '/TestEnvironment.php');
+
+abstract class Crud_Base extends PHPUnit_Framework_TestCase
+{
+	private $postData;
+
+	private $putData;
+
+	private $getData;
+
+	private $url;
+
+	private $keyProperty;
+
+	protected $method;
+
+	const JSON = 'json';
+	const FORM_DATA = 'form_params';
+
+	/**
+	 * Constructor. The $putData and $getData will be set to $postData if not set
+	 * @param string $url url of the endpoint 
+	 * @param string $keyProperty the property containing the key id
+	 * @param array $postData example data to use in post (create)
+	 * @param array $putData example data to use in put (update)
+	 * @param array $getData example data to compare with in get (read)
+	 */
+	public function __construct($url, $keyProperty, $postData, $putData = null, $getData = null)
+	{
+		$this->url = $url;
+		$this->keyProperty = $keyProperty;
+
+		$this->postData = $postData;
+		$this->putData = $putData ? $putData : $postData;
+		$this->getData = $getData ? $getData : $postData;
+
+		$this->method = Crud_Base::FORM_DATA;
+	}
+
+	protected function checkCountInitial($count, $result)
+	{
+		$this->assertGreaterThan(1, $count); // TODO Not sure about the one here.  zero should be ok
+	}
+
+	protected function fixExpectedType($expected, $result)
+	{
+		$expectedNew = null;
+		if (is_a($result, 'stdClass')) {
+			$expectedNew = new \stdClass();
+			foreach ($expected as $key => $value) {
+				$expectedNew->{$key} = $value;
+			}
+		} else {
+			$expectedNew = $this->postData;
+		}
+		return $expectedNew;
+	}
+
+	protected function removeKeyProperty($result)
+	{
+		if (isset($result->{$this->keyProperty}))
+		{
+			unset($result->{$this->keyProperty});
+		}
+		return $result;
+	}
+
+	protected function checkGetAfterPost($result)
+	{
+		$expected = $this->fixExpectedType($this->postData, $result);
+		$result = $this->removeKeyProperty($result);
+		$this->assertEquals($expected, $result, 'Failed GET after POST');
+	}
+
+	protected function checkGetAfterPut($result)
+	{
+		$expected = $this->fixExpectedType($this->putData, $result);
+		$result = $this->removeKeyProperty($result);
+		$this->assertEquals($expected, $result, 'Failed GET after PUT');
+	}
+
+	protected function getAll()
+	{
+		$client = TestEnvironment::client();
+		$response = $client->get($this->url, array(
+			'headers' => TestEnvironment::headers()
+		));
+		$this->assertEquals('200', $response->getStatusCode());
+		$result = $response->getBody();
+		$result = json_decode($result);
+		return $result;
+	}
+
+	public function testCRUD_Ok()
+	{
+		$client = TestEnvironment::client();
+
+		// List
+		$result = $this->getAll();
+		$count0 = count($result);
+		$this->checkCountInitial($count0, $result);
+
+		// Add
+		$response = $client->post($this->url, array(
+			'headers' => TestEnvironment::headers(),
+			$this->method => $this->postData
+		));
+		$this->assertEquals('201', $response->getStatusCode());
+		$result = $response->getBody();
+		$result = json_decode($result);
+		$id = $result->{$this->keyProperty};
+
+		$this->assertNotNull($id);
+
+		// List again
+		$result = $this->getAll();
+		$count1 = count($result);
+		$this->assertEquals($count0 + 1, $count1);
+
+		// Get by id
+		$response = $client->get($this->url . $id, array(
+			'headers' => TestEnvironment::headers()
+		));
+		$this->assertEquals('200', $response->getStatusCode());
+		$result = $response->getBody();
+		$result = json_decode($result);
+		$this->assertEquals($id, $result->{$this->keyProperty});
+		$this->checkGetAfterPost($result);
+
+		// Write back
+		$response = $client->put($this->url . $id, array(
+			'headers' => TestEnvironment::headers(),
+			$this->method => $this->putData
+		));
+
+		$this->assertEquals('200', $response->getStatusCode());
+		$result = $response->getBody();
+		$result = json_decode($result);
+
+		// List again
+		// Count should be the same, i.e. no increase
+		$result = $this->getAll();
+		$count1 = count($result);
+		$this->assertEquals($count0 + 1, $count1);
+		// The id should be the same
+		$this->assertEquals($id, $result[$count1 - 1]->{$this->keyProperty});
+
+		// Get by id
+		$response = $client->get($this->url . $id, array(
+			'headers' => TestEnvironment::headers()
+		));
+		$this->assertEquals('200', $response->getStatusCode());
+		$result = $response->getBody();
+		$result = json_decode($result);
+		$this->assertEquals($id, $result->{$this->keyProperty});
+		$this->checkGetAfterPut($result);
+
+		// Delete
+		$response = $client->delete($this->url . $id, array(
+			'headers' => TestEnvironment::headers()
+		));
+		$this->assertEquals('200', $response->getStatusCode());
+		$result = $response->getBody();
+		$result = json_decode($result);
+
+		// List again
+		$result = $this->getAll();
+		$count2 = count($result);
+		$this->assertEquals($count0, $count2);
+
+	}
+
+}

--- a/tests/Crud_Base.php
+++ b/tests/Crud_Base.php
@@ -45,7 +45,7 @@ abstract class Crud_Base extends PHPUnit_Framework_TestCase
 
 	protected function checkCountInitial($count, $result)
 	{
-		$this->assertGreaterThan(1, $count); // TODO Not sure about the one here.  zero should be ok
+		// $this->assertGreaterThan(0, $count); // TODO Not sure about the one here.  zero should be ok
 	}
 
 	protected function fixExpectedType($expected, $result)

--- a/tests/Customer_Test.php
+++ b/tests/Customer_Test.php
@@ -5,206 +5,81 @@ use GuzzleHttp\Client;
 require_once(__DIR__ . '/TestConfig.php');
 
 require_once(TEST_PATH . '/TestEnvironment.php');
+require_once(TEST_PATH . '/Crud_Base.php');
 
-class CustomerTest extends PHPUnit_Framework_TestCase
+const CUSTOMER_POST_DATA = array(
+	'name' => 'custname',
+	'debtor_ref' => 'debtor_ref',
+	'address' => 'address',
+	'tax_id' => 'tax_id',
+	'curr_code' => 'USD',
+	'credit_status' => '1',
+	'payment_terms' => '1',
+	'discount' => '0',
+	'pymt_discount' => '0',
+	'credit_limit' => '1000',
+	'sales_type' => '1',
+	'notes' => 'notes',
+	'dimension_id' => '0',
+	'dimension2_id' => '0',
+	'inactive' => '0',
+);
+
+const CUSTOMER_PUT_DATA = array(
+	'name' => 'new custname',
+	'debtor_ref' => 'new debtor_ref',
+	'address' => 'new address',
+	'tax_id' => 'new tax_id',
+	'curr_code' => 'NZD',
+	'credit_status' => '2',
+	'payment_terms' => '2',
+	'discount' => '1',
+	'pymt_discount' => '1',
+	'credit_limit' => '2000',
+	'sales_type' => '2',
+	'notes' => 'new notes',
+	'dimension_id' => '0',  // Not yet implemented
+	'dimension2_id' => '0', // Not yet implemented
+	'inactive' => '0',      // Not yet implemented
+);
+
+class CustomerTest extends Crud_Base
 {
 
-	public function testCRUD_Ok()
+	private $postData = CUSTOMER_POST_DATA;
+	
+	private $putData = CUSTOMER_PUT_DATA;
+	
+	public function __construct()
 	{
-		$client = TestEnvironment::client();
-
-		// List
-		$response = $client->get('/modules/api/customers/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count0 = count($result);
-		$this->assertEquals(0, $count0);
-
-		// Add
-// 		$id = TestEnvironment::createId();
-		$response = $client->post('/modules/api/customers/', array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'custname' => 'custname',
-				'cust_ref' => 'cust_ref',
-				'address' => 'address',
-				'tax_id' => 'tax_id',
-				'curr_code' => 'USD',
-				'credit_status' => '1',
-				'payment_terms' => '1',
-				'discount' => '0',
-				'pymt_discount' => '0',
-				'credit_limit' => '1000',
-				'sales_type' => '1',
-				'notes' => 'notes'
-			)
-		));
-		$this->assertEquals('201', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-		$id = $result->debtor_no;
-
-		$expected = new stdClass();
-		$expected->debtor_no = '1';
-		$expected->name = 'custname';
-		$expected->debtor_ref = 'cust_ref';
-		$expected->address = 'address';
-		$expected->tax_id = 'tax_id';
-		$expected->curr_code = 'USD';
-		$expected->sales_type = '1';
-		$expected->dimension_id = '0';
-		$expected->dimension2_id = '0';
-		$expected->credit_status = '1';
-		$expected->payment_terms = '1';
-		$expected->discount = '0';
-		$expected->pymt_discount = '0';
-		$expected->credit_limit = '1000';
-		$expected->notes = 'notes';
-		$expected->inactive = '0';
-
-		$expected->{ '0' } = '1';
-		$expected->{ '1' } = 'custname';
-		$expected->{ '2' }  = 'cust_ref';
-		$expected->{ '3' }  = 'address';
-		$expected->{ '4' }  = 'tax_id';
-		$expected->{ '5' }  = 'USD';
-		$expected->{ '6' }  = '1';
-		$expected->{ '7' }  = '0';
-		$expected->{ '8' }  = '0';
-		$expected->{ '9' }  = '1';
-		$expected->{ '10' }  = '1';
-		$expected->{ '11' }  = '0';
-		$expected->{ '12' }  = '0';
-		$expected->{ '13' }  = '1000';
-		$expected->{ '14' }  = 'notes';
-		$expected->{ '15' }  = '0';
-
-		$this->assertEquals($expected, $result);
-
-		// List again
-		$response = $client->get('/modules/api/customers/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
-
-		// Get by id
-		$response = $client->get('/modules/api/customers/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$this->assertEquals($expected, $result);
-
-		// Write back
-		$response = $client->put('/modules/api/customers/' . $id, array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'custname' => 'new custname',
-				'cust_ref' => 'new cust_ref',
-				'address' => 'new address',
-				'tax_id' => 'new tax_id',
-				'curr_code' => 'NZD',
-				'credit_status' => '2',
-				'payment_terms' => '2',
-				'discount' => '1',
-				'pymt_discount' => '1',
-				'credit_limit' => '2000',
-				'sales_type' => '2',
-				'notes' => 'new notes'
-			)
-		));
-
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		// Get by id to read back
-		$response = $client->get('/modules/api/customers/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$expected->name = 'new custname';
-		$expected->debtor_ref = 'new cust_ref';
-		$expected->address = 'new address';
-		$expected->tax_id = 'new tax_id';
-		$expected->curr_code = 'NZD';
-		$expected->sales_type = '2';
-// 		$expected->dimension_id = '0';
-// 		$expected->dimension2_id = '0';
-		$expected->credit_status = '2';
-		$expected->payment_terms = '2';
-		$expected->discount = '1';
-		$expected->pymt_discount = '1';
-		$expected->credit_limit = '2000';
-		$expected->notes = 'new notes';
-// 		$expected->inactive = '0';
-
-		$expected->{ '0' } = '1';
-		$expected->{ '1' } = 'new custname';
-		$expected->{ '2' }  = 'new cust_ref';
-		$expected->{ '3' }  = 'new address';
-		$expected->{ '4' }  = 'new tax_id';
-		$expected->{ '5' }  = 'NZD';
-		$expected->{ '6' }  = '2';
-		$expected->{ '7' }  = '0';
-		$expected->{ '8' }  = '0';
-		$expected->{ '9' }  = '2';
-		$expected->{ '10' }  = '2';
-		$expected->{ '11' }  = '1';
-		$expected->{ '12' }  = '1';
-		$expected->{ '13' }  = '2000';
-		$expected->{ '14' }  = 'new notes';
-		$expected->{ '15' }  = '0';
-
-		$this->assertEquals($expected, $result);
-
-		// List again
-		$response = $client->get('/modules/api/customers/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
-
-		$this->assertEquals($id, $result[$count1 - 1]->debtor_no);
-
-		// Delete
-		$response = $client->delete('/modules/api/customers/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		// List again
-		$response = $client->get('/modules/api/customers/', array(
-			'headers' => TestEnvironment::headers()
-		));
-
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count2 = count($result);
-		$this->assertEquals($count0, $count2);
-
+		parent::__construct(
+			'/modules/api/customers/',
+			'debtor_no',
+			$this->postData,
+			$this->putData
+		);
 	}
 
+	// 	public function testCRUD_Ok();
 }
+
+// class CustomerJsonTest extends Crud_Base
+// {
+
+// 	private $postData = CUSTOMER_POST_DATA;
+	
+// 	private $putData = CUSTOMER_PUT_DATA;
+	
+// 	public function __construct()
+// 	{
+// 		parent::__construct(
+// 			'/modules/api/customers/',
+// 			'debtor_no',
+// 			$this->postData,
+// 			$this->putData
+// 		);
+// 		$this->method = Crud_Base::JSON;
+// 	}
+
+// 	// 	public function testCRUD_Ok();
+// }

--- a/tests/GL_Test.php
+++ b/tests/GL_Test.php
@@ -55,12 +55,6 @@ class GLTest extends PHPUnit_Framework_TestCase
 		$expected->account_type = '1';
 		$expected->inactive = '0';
 
-		$expected->{ '0' } = '1060';
-		$expected->{ '1' } = '';
-		$expected->{ '2' } = 'Checking Account';
-		$expected->{ '3' } = '1';
-		$expected->{ '4' } = '0';
-
 		$this->assertEquals($expected, $result);
 	}
 
@@ -74,6 +68,15 @@ class GLTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals('200', $response->getStatusCode());
 		$result = $response->getBody();
 		$result = json_decode($result);
+
+		$count = count($result);
+		$this->assertTrue($count > 0, 'Count > 0');
+		$expected = new stdClass();
+		$expected->id = '1';
+		$expected->name = 'Current Assets';
+		$expected->class_id = '1';
+		$expected->parent = '';
+		$this->assertEquals($expected, $result[0]);
 	}
 
 }

--- a/tests/Inventory_Test.php
+++ b/tests/Inventory_Test.php
@@ -5,129 +5,110 @@ use GuzzleHttp\Client;
 require_once(__DIR__ . '/TestConfig.php');
 
 require_once(TEST_PATH . '/TestEnvironment.php');
+require_once(TEST_PATH . '/Crud_Base.php');
 
-class InventoryTest extends PHPUnit_Framework_TestCase
+const INVENTORY_POST_DATA = array(
+	'description' => 'description',
+	'long_description' => 'long description',
+	'category_id' => '1',
+	'tax_type_id' => '1',
+	'units' => 'ea',
+	'mb_flag' => '0',
+	'sales_account' => '1',
+	'inventory_account' => '1',
+	'cogs_account' => '1',
+	'adjustment_account' => '1',
+	'wip_account' => '1'
+);
+
+const INVENTORY_GET_DATA = array(
+	'description' => 'description',
+	'long_description' => 'long description',
+	'category_id' => '1',
+	'tax_type_id' => '1',
+	'units' => 'ea',
+	'mb_flag' => '0',
+	'sales_account' => '1',
+	'inventory_account' => '1',
+	'cogs_account' => '1',
+	'adjustment_account' => '1',
+	'wip_account' => '1',
+	'dimension_id' => '0',
+	'dimension2_id' => '0',
+	'purchase_cost' => '0',
+	'last_cost' => '0',
+	'material_cost' => '0',
+	'labour_cost' => '0',
+	'overhead_cost' => '0',
+	'inactive' => '0',
+	'no_sale' => '0',
+	'no_purchase' => '0',
+	'editable' => '1',
+	'depreciation_method' => 'D',
+	'depreciation_rate' => '100',
+	'depreciation_factor' => '1',
+	'depreciation_start' => '0000-00-00',
+	'depreciation_date' => '0000-00-00',
+	'fa_class_id' => '',
+	'tax_type_name' => 'Regular',
+);
+
+class InventoryTest extends Crud_Base
 {
 
-	public function testCRUD_Ok()
+	private $postData = INVENTORY_POST_DATA;
+	
+	private $putData;
+	
+	public function __construct()
 	{
-		$client = TestEnvironment::client();
+		// Note: The primary key needs to be provided by the client.
+		// It is not an auto-increment property.
+		$this->postData['stock_id'] = TestEnvironment::createId();
+		$this->putData = $this->postData;
+		$this->putData['description'] = 'new description';
+		$this->putData['long_description'] = 'new long description';
 
-		// List
-		$response = $client->get('/modules/api/inventory/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count0 = count($result);
-
-		// Add
-		$id = TestEnvironment::createId();
-		$response = $client->post('/modules/api/inventory/', array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'stock_id' => $id,
-				'description' => 'description',
-				'long_description' => 'long description',
-				'category_id' => '1',
-				'tax_type_id' => '1',
-				'units' => 'ea',
-				'mb_flag' => '0',
-				'sales_account' => '1',
-				'inventory_account' => '1',
-				'cogs_account' => '1',
-				'adjustment_account' => '1',
-				'wip_account' => '1'
-			)
-		));
-		$this->assertEquals('201', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$this->assertEquals($id, $result->stock_id);
-// 		var_dump($result);
-
-		// List again
-		$response = $client->get('/modules/api/inventory/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
-
-		// Get by id
-		$response = $client->get('/modules/api/inventory/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		// Write back
-		$response = $client->put('/modules/api/inventory/' . $id, array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'stock_id' => $id, // TODO This shouldn't be required for an edit CP 2014-10
-				'description' => 'changed',
-				'long_description' => 'changed long description',
-				'category_id' => '1',
-				'tax_type_id' => '1',
-				'units' => 'ea',
-				'mb_flag' => '0',
-				'sales_account' => '1',
-				'inventory_account' => '1',
-				'cogs_account' => '1',
-				'adjustment_account' => '1',
-				'wip_account' => '1'
-			)
-		));
-
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		// List again
-		$response = $client->get('/modules/api/inventory/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
-
-		$this->assertEquals($id, $result[0]->stock_id);
-		$this->assertEquals('changed', $result[0]->description);
-		$this->assertEquals('changed long description', $result[0]->long_description);
-
-		// Delete
-		$response = $client->delete('/modules/api/inventory/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		// List again
-		$response = $client->get('/modules/api/inventory/', array(
-			'headers' => TestEnvironment::headers()
-		));
-
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count2 = count($result);
-		$this->assertEquals($count0, $count2);
-
+		parent::__construct(
+			'/modules/api/inventory/',
+			'stock_id',
+			$this->postData,
+			$this->putData,
+			INVENTORY_GET_DATA
+		);
 	}
 
+	protected function checkGetAfterPost($result)
+	{
+		$expected = INVENTORY_GET_DATA;
+		$expected['stock_id'] = $this->postData['stock_id'];
+		$expected = $this->fixExpectedType($expected, $result);
+		// $result = $this->removeKeyProperty($result);
+		$this->assertEquals($expected, $result, 'Failed GET after POST');
+	}
+
+	protected function checkGetAfterPut($result)
+	{
+		$expected = INVENTORY_GET_DATA;
+		$expected['stock_id'] = $this->putData['stock_id'];
+		// Update the expected with the modifications that we PUT
+		foreach ($this->putData as $key => $value) {
+			if (isset($expected[$key])) {
+				$expected[$key] = $value;
+			}
+		}
+		$expected = $this->fixExpectedType($expected, $result);
+		// $result = $this->removeKeyProperty($result);
+		$this->assertEquals($expected, $result, 'Failed GET after PUT');
+	}
+
+	// 	public function testCRUD_Ok();
+
+
+}
+
+class InventoryOtherTest extends PHPUnit_Framework_TestCase
+{
 	public function testLocations_Ok()
 	{
 		$client = TestEnvironment::client();

--- a/tests/Supplier_Test.php
+++ b/tests/Supplier_Test.php
@@ -5,10 +5,75 @@ use GuzzleHttp\Client;
 require_once(__DIR__ . '/TestConfig.php');
 
 require_once(TEST_PATH . '/TestEnvironment.php');
+require_once(TEST_PATH . '/Crud_Base.php');
 
-class SupplierTest extends PHPUnit_Framework_TestCase
+const SUPPLIER_POST_DATA = array(
+	'supp_name' => 'supp_name',
+	'supp_ref' => 'supp_ref',
+	'address' => 'address',
+	'supp_address' => 'supp_address',
+	'gst_no' => 'gst_no',
+	'website' => 'website',
+	'supp_account_no' => 'supp_account_no',
+	'bank_account' => 'bank_account',
+	'credit_limit' => '1000',
+	'curr_code' => 'USD',
+	'payment_terms' => '1',
+	'payable_account' => '1010',
+	'purchase_account' => '1020',
+	'payment_discount_account' => '1030',
+	'notes' => 'notes',
+	'tax_group_id' => '1',
+	'tax_included' => '1',
+	'contact' => '',        // Not yet implemented
+	'dimension_id' => '0',  // Not yet implemented
+	'dimension2_id' => '0', // Not yet implemented
+	'inactive' => '0',      // Not yet implemented
+);
+
+const SUPPLIER_PUT_DATA = array(
+	'supp_name' => 'new supp_name',
+	'supp_ref' => 'new supp_ref',
+	'address' => 'new address',
+	'supp_address' => 'new supp_address',
+	'gst_no' => 'new gst_no',
+	'website' => 'new website',
+	'supp_account_no' => 'new supp_account_no',
+	'bank_account' => 'new bank_account',
+	'credit_limit' => '2000',
+	'curr_code' => 'NZD',
+	'payment_terms' => '2',
+	'payable_account' => '2010',
+	'purchase_account' => '2020',
+	'payment_discount_account' => '2030',
+	'notes' => 'new notes',
+	'tax_group_id' => '2',
+	'tax_included' => '2',
+	'contact' => '',        // Not yet implemented
+	'dimension_id' => '0',  // Not yet implemented
+	'dimension2_id' => '0', // Not yet implemented
+	'inactive' => '0',      // Not yet implemented
+);
+
+class SupplierTest extends Crud_Base
 {
 
+	private $postData = SUPPLIER_POST_DATA;
+	
+	private $putData = SUPPLIER_PUT_DATA;
+	
+	public function __construct()
+	{
+		parent::__construct(
+			'/modules/api/suppliers/',
+			'supplier_id',
+			$this->postData,
+			$this->putData
+		);
+	}
+
+	// 	public function testCRUD_Ok();
+/*	
 	public function testCRUD_Ok()
 	{
 		$client = TestEnvironment::client();
@@ -242,5 +307,5 @@ class SupplierTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($count0, $count2);
 
 	}
-
+*/
 }

--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -25,8 +25,8 @@ class TestEnvironment
 		$response = $client->post('/modules/api/customers/', array(
 			'headers' => TestEnvironment::headers(),
 			'form_params' => array(
-				'custname' => $name,
-				'cust_ref' => $ref,
+				'name' => $name,
+				'debtor_ref' => $ref,
 				'address' => 'address',
 				'tax_id' => 'tax_id',
 				'curr_code' => 'USD',

--- a/upload-exclude-zip.txt
+++ b/upload-exclude-zip.txt
@@ -1,4 +1,5 @@
 .git/*
+*/.git/*
 .gitignore
 .hg/*
 .hgtags

--- a/util.php
+++ b/util.php
@@ -5,7 +5,8 @@ Name: REST API Utils
 Free software under GNU GPL
 ***********************************************/
 
-function api_login(){
+function api_login()
+{
 	$app = \Slim\Slim::getInstance('SASYS');
 	$app->hook('slim.before', function () use ($app) {
 		$req = $app->request();
@@ -20,36 +21,53 @@ function api_login(){
 
 		$succeed = $_SESSION["wa_current_user"]->login($company,
 					$user, $password);
-		if(!$succeed){
+		if (!$succeed) {
 			$app->halt(403, 'Bad Login For Company: ' . $company . ' With User: ' . $user);
 		}
 	}, 1);
 }
 
-function api_response($code, $body){
+function api_response($code, $body)
+{
 	$app = \Slim\Slim::getInstance('SASYS');
 	$app->response()->status($code);
 	$app->response()->body($body);
 }
 
-function api_success_response($body){
+function api_success_response($body)
+{
 	$app = \Slim\Slim::getInstance('SASYS');
 	$app->response()->status(200);
 	$app->response()->body($body);
 	//$app->response()->['Content-Type'] = $content_type;
 }
 
-function api_create_response($body){
+function api_create_response($body)
+{
 	$app = \Slim\Slim::getInstance('SASYS');
 	$app->response()->status(201);
 	$app->response()->body($body);
 	//$app->response()->['Content-Type'] = $content_type;
 }
 
-function api_error($code, $msg){
+function api_error($code, $msg)
+{
 	$app = \Slim\Slim::getInstance('SASYS');
 	$app->halt($code, json_encode(array('success' => 0, 'msg' => $msg)));
-
 }
 
-?>
+function api_ensureAssociativeArray($a)
+{
+	if (!$a)
+	{
+		$a = array();
+	}
+	foreach ($a as $key => $value)
+	{
+		if (is_int($key))
+		{
+			unset($a[$key]);
+		}
+	}
+	return $a;
+}


### PR DESCRIPTION
- Refactor tests to ensure consistency in POST and PUT api.
  Added tests/Crud_Base.php
- Add api_ensureAssociateArray to remove the numeric index elements that come from the Front Accounting functions.
- The category end point now follows the database schema more closely for property names.
- The customers end point now follows the database schema more closely for property names.