### PR TITLE
GL Accounts, Dimensions, and Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ node_modules/
 _frontaccounting
 *.zip
 *.tgz
-
+public/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # CHANGELOG
 
+#### 21 June 2018
+
+- Add full CRUD for Bank Accounts under bankaccounts endpoint.
+- Fix formatting of code under src/ and test/ to conform to [PSR-2](https://www.php-fig.org/psr/psr-2/)
+
 #### 20 June 2018
 
+- Add full CRUD for GLAccounts under glaccounts endpoint.
+- Add CRUD for Dimensions under dimensions endpoint.
 - Add static api generator and sample documentation.
 
 #### 19 June 2018

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+#### 20 June 2018
+
+- Add static api generator and sample documentation.
+
 #### 19 June 2018
 
 - Core VARLIB_PATH and VARLOG_PATH inclusions added [see this commit](https://github.com/FrontAccountingERP/FA/commit/4a37a28c49bf900dcc370fd3f21186cedcd632c9).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Some of them have not been tested yet so be carefull.
 
 Report issues you find in our GitHub Issue Tracker. Please report with as much detail as you can. Simply saying "It doesn't work" will gain you sympathy, but not a lot else.
 
-Want to contribute code? Go right ahead, fork the project on GitHub, pull requests are welcome.
+Want to contribute code? Go right ahead, fork the project on GitHub, pull requests are welcome. Note that we're trying to follow the [PSR-2 Coding Style Guide](https://www.php-fig.org/psr/psr-2/).
+
 ## Contact
 
 Any question about this you can always contact me: andres.amaya.diaz@gmail.com

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,11 @@
 {
     "require": {
-        "slim/slim": "~2.4.3"
+        "slim/slim": "~2.6.3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.2.6",
-        "guzzlehttp/guzzle": "~6.3"
+        "guzzlehttp/guzzle": "~6.3",
+        "zircote/swagger-php": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,28 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8490bde2228467df9a73a1501935fc60",
+    "content-hash": "50c0ff93c13619400af79e2da0ea7998",
     "packages": [
         {
             "name": "slim/slim",
-            "version": "2.4.3",
+            "version": "2.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slimphp/Slim.git",
-                "reference": "4906b77a07c7bd6ff1a99aea903e940a2d4fa106"
+                "reference": "9224ed81ac1c412881e8d762755e3d76ebf580c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slimphp/Slim/zipball/4906b77a07c7bd6ff1a99aea903e940a2d4fa106",
-                "reference": "4906b77a07c7bd6ff1a99aea903e940a2d4fa106",
+                "url": "https://api.github.com/repos/slimphp/Slim/zipball/9224ed81ac1c412881e8d762755e3d76ebf580c0",
+                "reference": "9224ed81ac1c412881e8d762755e3d76ebf580c0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
             },
             "suggest": {
-                "ext-mcrypt": "Required for HTTP cookie encryption"
+                "ext-mcrypt": "Required for HTTP cookie encryption",
+                "phpseclib/mcrypt_compat": "Polyfil for mcrypt extension"
             },
             "type": "library",
             "autoload": {
@@ -50,10 +51,78 @@
                 "rest",
                 "router"
             ],
-            "time": "2014-04-05T18:33:59+00:00"
+            "time": "2017-01-07T12:21:41+00:00"
         }
     ],
     "packages-dev": [
+        {
+            "name": "doctrine/annotations",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/54cacc9b81758b14e3ce750f205a393d52339e97",
+                "reference": "54cacc9b81758b14e3ce750f205a393d52339e97",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "^5.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "time": "2017-02-24T16:22:25+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.0.5",
@@ -107,6 +176,60 @@
                 "instantiate"
             ],
             "time": "2015-06-14T21:17:01+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Lexer\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "lexer",
+                "parser"
+            ],
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1037,8 +1160,57 @@
             "time": "2015-06-21T13:59:46+00:00"
         },
         {
+            "name": "symfony/finder",
+            "version": "v3.3.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
+                "reference": "138af5ec075d4b1d1bd19de08c38a34bb2d7d880",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5.9|>=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2017-11-05T15:47:03+00:00"
+        },
+        {
             "name": "symfony/yaml",
-            "version": "v2.8.30",
+            "version": "v2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
@@ -1084,6 +1256,68 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2017-11-05T15:25:56+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "2.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "5393727e0c2fe822252f82230a5975572ca32d45"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/5393727e0c2fe822252f82230a5975572ca32d45",
+                "reference": "5393727e0c2fe822252f82230a5975572ca32d45",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "*",
+                "php": ">=5.6",
+                "symfony/finder": ">=2.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.8 <=5.6",
+                "squizlabs/php_codesniffer": ">=2.7",
+                "zendframework/zend-form": "<2.8"
+            },
+            "bin": [
+                "bin/swagger"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Swagger\\": "src"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com",
+                    "homepage": "http://www.zircote.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "http://bfanger.nl"
+                }
+            ],
+            "description": "Swagger-PHP - Generate interactive documentation for your RESTful API using phpdoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php/",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "time": "2017-10-27T13:08:09+00:00"
         }
     ],
     "aliases": [],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -27,7 +27,7 @@ var execute = function(command, options, callback) {
 };
 
 var paths = {
-  src: ['**/*.inc', '**/*.php', '!vendor/**'],
+  src: ['**/*.inc', '**/*.php', '*.php', '*.inc', 'index.php', '!vendor/**'],
   testUnit: ['tests/*.php']
 };
 
@@ -87,6 +87,26 @@ gulp.task('test-travis', gulpSequence('env-test-travis', 'test-only'));
 
 gulp.task('test-watch', function() {
   gulp.watch([paths.testUnit, paths.src], ['test']);
+});
+
+gulp.task('doc-swagger-json', function(cb) {
+  var options = {
+    dryRun: false,
+    silent: false
+  };
+  execute(
+    '/usr/bin/env php vendor/zircote/swagger-php/bin/swagger src/ index.php',
+    options,
+    cb
+  );
+});
+
+gulp.task('doc-watch', function() {
+  gulp.watch(['src/*.php', '*.php'], ['doc-swagger-json']);
+  // gulp.watch('index.php', function() {
+  //   console.log('boo');
+  //   gulp.start('doc-swagger-json');
+  // });
 });
 
 gulp.task('package-zip', ['package-vendor'], function(cb) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,7 +96,7 @@ gulp.task('package-zip', ['package-vendor'], function(cb) {
     src: "./",
     name: "frontaccounting",
     version: "2.4",
-    release: "-api.module.1.4"
+    release: "-api.module.1.5"
   };
   execute(
     'rm -f *.zip && cd <%= src %> && zip -r -x@./upload-exclude-zip.txt -y -q ./<%= name %>-<%= version %><%= release %>.zip .',
@@ -112,7 +112,7 @@ gulp.task('package-tar', ['package-vendor'], function(cb) {
     src: "./",
     name: "frontaccounting",
     version: "2.4",
-    release: "-api.module.1.4"
+    release: "-api.module.1.5"
   };
   execute(
     'rm -f *.tgz && cd <%= src %> && tar -cvzf ./<%= name %>-<%= version %><%= release %>.tgz -X upload-exclude.txt * .htaccess',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,6 +101,23 @@ gulp.task('doc-swagger-json', function(cb) {
   );
 });
 
+// This task builds static documentation in the public folder from the swagger.json file using spectacle
+// spectacle is assumed to be globally installed on the system, e.g. sudo npm install -g spectacle-docs
+// more information on the Spectacle static docs generator: https://github.com/sourcey/spectacle
+gulp.task('doc-spectacle', function(cb) {
+  var options = {
+    dryRun: false,
+    silent: false
+  };
+  execute(
+    'spectacle -q swagger.json',
+    options,
+    cb
+  );
+});
+
+gulp.task('doc', gulpSequence('doc-swagger-json', 'doc-spectacle'));
+
 gulp.task('doc-watch', function() {
   gulp.watch(['src/*.php', '*.php'], ['doc-swagger-json']);
   // gulp.watch('index.php', function() {

--- a/index.php
+++ b/index.php
@@ -27,6 +27,30 @@ Free software under GNU GPL
 --> 6-Sept-2014
 - Several bug fixes and additions Thanks to Cambell Prince
 ***********************************************/
+
+/**
+ * @SWG\Swagger(
+ *     host="frontaccounting.demo.saygoweb.com",
+ *     basePath="/modules/api",
+ *     @SWG\Info(
+ *         version="2.4-1.2",
+ *         title="Front Accounting Simple API",
+ *         description="This is a simple REST API as a Front Accounting module [https://github.com/cambell-prince/FrontAccountingSimpleAPI](https://github.com/cambell-prince/FrontAccountingSimpleAPI).",
+ *         @SWG\Contact(
+ *             email="cambell.prince@gmail.com"
+ *         ),
+ *         @SWG\License(
+ *             name="GPL V2.0",
+ *             url="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html"
+ *         )
+ *     ),
+ *     @SWG\ExternalDocumentation(
+ *         description="Find out more about Front Accounting Simple API",
+ *         url="http://swagger.io"
+ *     )
+ * )
+ */
+
 ini_set('html_errors', false);
 ini_set('xdebug.show_exception_trace', 0);
 // ini_set('xdebug.auto_trace', 2);

--- a/index.php
+++ b/index.php
@@ -281,6 +281,18 @@ $rest->group('/bankaccounts', function () use ($rest) {
     $rest->get('/:id', function ($id) use ($rest) {
         $rest->bankAccounts->getById($rest, $id);
     });
+    // Insert GL Accounts
+    $rest->post('/', function () use ($rest) {
+        $rest->bankAccounts->post($rest);
+    });
+    // Update GL Accounts
+    $rest->put('/:id', function ($id) use ($rest) {
+        $rest->bankAccounts->put($rest, $id);
+    });
+    // Delete GL Accounts
+    $rest->delete('/:id', function ($id) use ($rest) {
+        $rest->bankAccounts->delete($rest, $id);
+    });
 });
 // ------------------------------- Bank Accounts -------------------------------
 
@@ -289,7 +301,7 @@ $rest->container->singleton('glAccounts', function () {
     return new GLAccounts();
 });
 $rest->group('/glaccounts', function () use ($rest) {
-    // Get GL Accounts
+    // Get All GL Accounts
     $rest->get('/', function () use ($rest) {
         $rest->glAccounts->get($rest);
     });

--- a/index.php
+++ b/index.php
@@ -11,6 +11,8 @@ use FAAPI\GLAccounts;
 use FAAPI\Currencies;
 use FAAPI\InventoryCosts;
 use FAAPI\Sales;
+use FAAPI\Dimensions;
+
 /**********************************************
 Author: Andres Amaya
 Name: SASYS REST API
@@ -473,6 +475,39 @@ $rest->group('/sales', function () use($rest)
 	});
 });
 // ------------------------------- Sales --------------------------------
+// ---------------------------- Dimensions ------------------------------
+$rest->container->singleton('dimensions', function() {
+	return new Dimensions();
+});
+$rest->group('/dimensions', function () use($rest)
+{
+	// Get Dimension
+	$rest->get('/:ref', function ($ref) use($rest)
+	{
+		$rest->dimensions->getById($rest, $ref);
+	});
+	// Insert Dimension
+	$rest->post('/', function () use($rest)
+	{
+		$rest->dimensions->post($rest);
+	});
+	// Edit Dimension
+	$rest->put('/:ref', function ($ref) use($rest)
+	{
+		$rest->dimensions->put($rest, $ref);
+	});
+	// Delete Dimension
+	$rest->delete('/:ref', function ($ref) use($rest)
+	{
+		$rest->dimensions->delete($rest, $ref);
+	});
+	// All Dimensions
+	$rest->get('/', function () use($rest)
+	{
+		$rest->dimensions->get($rest);
+	});
+});
+// ---------------------------- Dimensions ------------------------------
 
 // Init API
 $rest->run();

--- a/index.php
+++ b/index.php
@@ -352,6 +352,21 @@ $rest->group('/glaccounts', function () use($rest)
 	{
 		$rest->glAccounts->getById($rest, $id);
 	});
+	// Insert GL Accounts
+	$rest->post('/', function () use($rest)
+	{
+		$rest->glAccounts->post($rest);
+	});
+	// Update GL Accounts
+	$rest->put('/:id', function ($id) use($rest)
+	{
+		$rest->glAccounts->put($rest, $id);
+	});
+	// Delete GL Accounts
+	$rest->delete('/:id', function ($id) use($rest)
+	{
+		$rest->glAccounts->delete($rest, $id);
+	});
 });
 // Get GL Account Types
 $rest->get('/glaccounttypes/', function () use($rest)

--- a/index.php
+++ b/index.php
@@ -281,15 +281,15 @@ $rest->group('/bankaccounts', function () use ($rest) {
     $rest->get('/:id', function ($id) use ($rest) {
         $rest->bankAccounts->getById($rest, $id);
     });
-    // Insert GL Accounts
+    // Insert Bank Account
     $rest->post('/', function () use ($rest) {
         $rest->bankAccounts->post($rest);
     });
-    // Update GL Accounts
+    // Update Bank Account
     $rest->put('/:id', function ($id) use ($rest) {
         $rest->bankAccounts->put($rest, $id);
     });
-    // Delete GL Accounts
+    // Delete Bank Account
     $rest->delete('/:id', function ($id) use ($rest) {
         $rest->bankAccounts->delete($rest, $id);
     });
@@ -309,15 +309,15 @@ $rest->group('/glaccounts', function () use ($rest) {
     $rest->get('/:id', function ($id) use ($rest) {
         $rest->glAccounts->getById($rest, $id);
     });
-    // Insert GL Accounts
+    // Insert GL Account
     $rest->post('/', function () use ($rest) {
         $rest->glAccounts->post($rest);
     });
-    // Update GL Accounts
+    // Update GL Account
     $rest->put('/:id', function ($id) use ($rest) {
         $rest->glAccounts->put($rest, $id);
     });
-    // Delete GL Accounts
+    // Delete GL Account
     $rest->delete('/:id', function ($id) use ($rest) {
         $rest->glAccounts->delete($rest, $id);
     });

--- a/index.php
+++ b/index.php
@@ -17,39 +17,28 @@ use FAAPI\Dimensions;
 Author: Andres Amaya
 Name: SASYS REST API
 Free software under GNU GPL
-
---> 15-July-2013:
-- Added .htaccess
-- GET with pagination
-- Sales Methods
-
---> 14-June-2013:
-- Added POST /locations/ To Add A Location Thanks to Richard Vinke
-
---> 6-Sept-2014
-- Several bug fixes and additions Thanks to Cambell Prince
 ***********************************************/
 
 /**
  * @SWG\Swagger(
- *     host="frontaccounting.demo.saygoweb.com",
- *     basePath="/modules/api",
- *     @SWG\Info(
- *         version="2.4-1.2",
- *         title="Front Accounting Simple API",
- *         description="This is a simple REST API as a Front Accounting module [https://github.com/cambell-prince/FrontAccountingSimpleAPI](https://github.com/cambell-prince/FrontAccountingSimpleAPI).",
- *         @SWG\Contact(
- *             email="cambell.prince@gmail.com"
- *         ),
- *         @SWG\License(
- *             name="GPL V2.0",
- *             url="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html"
- *         )
+ *   host="demo.saygoweb.com",
+ *   basePath="/frontaccounting/modules/api",
+ *   @SWG\Info(
+ *     version="2.4-1.2",
+ *     title="Front Accounting Simple API",
+ *     description="This is a simple REST API as a Front Accounting module [https://github.com/cambell-prince/FrontAccountingSimpleAPI](https://github.com/cambell-prince/FrontAccountingSimpleAPI).",
+ *     @SWG\Contact(
+ *       email="cambell.prince@gmail.com"
  *     ),
- *     @SWG\ExternalDocumentation(
- *         description="Find out more about Front Accounting Simple API",
- *         url="http://swagger.io"
+ *     @SWG\License(
+ *       name="GPL V2.0",
+ *       url="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html"
  *     )
+ *   ),
+ *   @SWG\ExternalDocumentation(
+ *     description="Find out more about Front Accounting Simple API",
+ *     url="https://github.com/cambell-prince/FrontAccountingSimpleAPI"
+ *   )
  * )
  */
 
@@ -57,30 +46,24 @@ ini_set('html_errors', false);
 ini_set('xdebug.show_exception_trace', 0);
 // ini_set('xdebug.auto_trace', 2);
 
-include_once ('config_api.php');
+include_once('config_api.php');
 
 global $security_areas, $security_groups, $security_headings, $path_to_root, $db, $db_connections;
 
 $page_security = 'SA_API';
 
-include_once (API_ROOT . "/session-custom.inc");
-include_once (API_ROOT . "/vendor/autoload.php");
+include_once(API_ROOT . "/session-custom.inc");
+include_once(API_ROOT . "/vendor/autoload.php");
 
-include_once (API_ROOT . "/util.php");
+include_once(API_ROOT . "/util.php");
 
-include_once (FA_ROOT . "/includes/date_functions.inc");
-include_once (FA_ROOT . "/includes/data_checks.inc");
-
-// echo "sales quote => ".ST_SALESQUOTE;
-// echo "sales order => ".ST_SALESORDER;
-// echo "sales invoice => ".ST_SALESINVOICE;
-// echo "cust delivery => ".ST_CUSTDELIVERY;
-// echo "cust credit => ".ST_CUSTCREDIT;
+include_once(FA_ROOT . "/includes/date_functions.inc");
+include_once(FA_ROOT . "/includes/data_checks.inc");
 
 $rest = new \Slim\Slim(array(
-	'log.enabled' => true,
-	'mode' => 'debug',
-	'debug' => true
+    'log.enabled' => true,
+    'mode' => 'debug',
+    'debug' => true
 ));
 $rest->setName('SASYS');
 
@@ -93,13 +76,14 @@ define("RESULTS_PER_PAGE", 2);
 
 class JsonToFormData extends \Slim\Middleware
 {
-	function call() {
-		$env = $this->app->environment();
-		if (is_array($env['slim.input'])) {
-			$env['slim.request.form_hash'] = $env['slim.input'];
-		}
-		$this->next->call();
-	}
+    public function call()
+    {
+        $env = $this->app->environment();
+        if (is_array($env['slim.input'])) {
+            $env['slim.request.form_hash'] = $env['slim.input'];
+        }
+        $this->next->call();
+    }
 }
 
 /*
@@ -111,310 +95,260 @@ $rest->add(new \Slim\Middleware\ContentTypes());
 
 // API Routes
 // ------------------------------- Items -------------------------------
-$rest->container->singleton('inventory', function() {
-	return new Inventory();
+$rest->container->singleton('inventory', function () {
+    return new Inventory();
 });
-$rest->group('/inventory', function () use($rest)
-{
-	// Get Items
-	$rest->get('/', function() use($rest) {
-		$rest->inventory->get($rest);
-	});
-	// Get Specific Item by Stock Id
-	$rest->get('/:id', function ($id) use($rest)
-	{
-		$rest->inventory->getById($rest, $id);
-	});
-	// Add Item
-	$rest->post('/', function () use($rest)
-	{
-		$rest->inventory->post($rest);
-	});
-	// Edit Specific Item
-	$rest->put('/:id', function ($id) use($rest)
-	{
-		$rest->inventory->put($rest, $id);
-	});
-	// Delete Specific Item
-	$rest->delete('/:id', function ($id) use($rest)
-	{
-		$rest->inventory->delete($rest, $id);
-	});
+$rest->group('/inventory', function () use ($rest) {
+    // Get Items
+    $rest->get('/', function () use ($rest) {
+        $rest->inventory->get($rest);
+    });
+    // Get Specific Item by Stock Id
+    $rest->get('/:id', function ($id) use ($rest) {
+        $rest->inventory->getById($rest, $id);
+    });
+    // Add Item
+    $rest->post('/', function () use ($rest) {
+        $rest->inventory->post($rest);
+    });
+    // Edit Specific Item
+    $rest->put('/:id', function ($id) use ($rest) {
+        $rest->inventory->put($rest, $id);
+    });
+    // Delete Specific Item
+    $rest->delete('/:id', function ($id) use ($rest) {
+        $rest->inventory->delete($rest, $id);
+    });
 });
 // ------------------------------- Items -------------------------------
 
 // ------------------------------- Inventory Locations -------------------------------
-$rest->container->singleton('inventoryLocations', function() {
-	return new InventoryLocations();
+$rest->container->singleton('inventoryLocations', function () {
+    return new InventoryLocations();
 });
-$rest->group('/locations', function () use($rest)
-{
-	// Get Locations
-	$rest->get('/', function () use($rest)
-	{
-		$rest->inventoryLocations->get($rest);
-	});
+$rest->group('/locations', function () use ($rest) {
+    // Get Locations
+    $rest->get('/', function () use ($rest) {
+        $rest->inventoryLocations->get($rest);
+    });
 
-	// Add Location, added by Richard Vinke
-	$rest->post('/', function () use($rest)
-	{
-		$rest->inventoryLocations->post($rest);
-	});
+    // Add Location, added by Richard Vinke
+    $rest->post('/', function () use ($rest) {
+        $rest->inventoryLocations->post($rest);
+    });
 });
 // ------------------------------- Inventory Locations -------------------------------
 
 // ------------------------------- Stock Adjustments -------------------------------
 // Add Stock Adjustment
-$rest->post('/stock/', function () use($rest)
-{
-	include_once (API_ROOT . "/inventory.inc");
-	stock_adjustment_add();
+$rest->post('/stock/', function () use ($rest) {
+    include_once(API_ROOT . "/inventory.inc");
+    stock_adjustment_add();
 });
 // ------------------------------- Stock Adjustments -------------------------------
 
 // ------------------------------- Item Categories -------------------------------
-$rest->container->singleton('category', function() {
-	return new Category();
+$rest->container->singleton('category', function () {
+    return new Category();
 });
-$rest->group('/category', function () use($rest)
-{
-	// Get Items Categories
-	$rest->get('/', function () use($rest)
-	{
-		$rest->category->get($rest);
-	});
-	// Get Specific Item Category
-	$rest->get('/:id', function ($id) use($rest)
-	{
-		$rest->category->getById($rest, $id);
-	});
-	// Add Item Category
-	$rest->post('/', function () use($rest)
-	{
-		$rest->category->post($rest);
-	});
-	// Edit Item Category
-	$rest->put('/:id', function ($id) use($rest)
-	{
-		$rest->category->put($rest, $id);
-	});
-	// Delete Item Category
-	$rest->delete('/:id', function ($id) use($rest)
-	{
-		$rest->category->delete($rest, $id);
-	});
+$rest->group('/category', function () use ($rest) {
+    // Get Items Categories
+    $rest->get('/', function () use ($rest) {
+        $rest->category->get($rest);
+    });
+    // Get Specific Item Category
+    $rest->get('/:id', function ($id) use ($rest) {
+        $rest->category->getById($rest, $id);
+    });
+    // Add Item Category
+    $rest->post('/', function () use ($rest) {
+        $rest->category->post($rest);
+    });
+    // Edit Item Category
+    $rest->put('/:id', function ($id) use ($rest) {
+        $rest->category->put($rest, $id);
+    });
+    // Delete Item Category
+    $rest->delete('/:id', function ($id) use ($rest) {
+        $rest->category->delete($rest, $id);
+    });
 });
 // ------------------------------- Item Categories -------------------------------
 
 // ------------------------------- Tax Types -------------------------------
 // Tax Types
-$rest->container->singleton('taxTypes', function() {
-	return new TaxTypes();
+$rest->container->singleton('taxTypes', function () {
+    return new TaxTypes();
 });
-$rest->group('/taxtypes', function () use($rest)
-{
-	// Get All Item Tax Types
-	$rest->get('/', function () use($rest)
-	{
-		$rest->taxTypes->get($rest);
-	});
-	// Get Specific Tax Type
-	$rest->get('/:id', function ($id) use($rest)
-	{
-		$rest->taxTypes->getById($rest, $id);
-	});
+$rest->group('/taxtypes', function () use ($rest) {
+    // Get All Item Tax Types
+    $rest->get('/', function () use ($rest) {
+        $rest->taxTypes->get($rest);
+    });
+    // Get Specific Tax Type
+    $rest->get('/:id', function ($id) use ($rest) {
+        $rest->taxTypes->getById($rest, $id);
+    });
 });
 // ------------------------------- Tax Types -------------------------------
 
 // ------------------------------- Tax Groups -------------------------------
 // Tax Groups
-$rest->container->singleton('taxGroups', function() {
-	return new TaxGroups();
+$rest->container->singleton('taxGroups', function () {
+    return new TaxGroups();
 });
 
 // Get All Tax Groups
-$rest->get('/taxgroups/', function () use($rest)
-{
-	$rest->taxGroups->get($rest);
+$rest->get('/taxgroups/', function () use ($rest) {
+    $rest->taxGroups->get($rest);
 });
 // ------------------------------- Tax Groups -------------------------------
 
 // ------------------------------- Customers -------------------------------
-$rest->container->singleton('customers', function() {
-	return new Customers();
+$rest->container->singleton('customers', function () {
+    return new Customers();
 });
-$rest->group('/customers', function () use($rest)
-{
-	// Get Customer General Info
-	$rest->get('/:id', function ($id) use($rest)
-	{
-		$rest->customers->getById($rest, $id);
-	});
-	// All Customers
-	$rest->get('/', function () use($rest)
-	{
-		$rest->customers->get($rest);
-	});
-	// Add Customer
-	$rest->post('/', function () use($rest)
-	{
-		$rest->customers->post($rest);
-	});
-	// Edit Customer
-	$rest->put('/:id', function ($id) use($rest)
-	{
-		$rest->customers->put($rest, $id);
-	});
-	// Delete Customer
-	$rest->delete('/:id', function ($id) use($rest)
-	{
-		$rest->customers->delete($rest, $id);
-	});
-	// Get Customer Branches
-	$rest->get('/:id/branches/', function ($id) use($rest)
-	{
-		$rest->customers->getBranches($rest, $id);
-	});
+$rest->group('/customers', function () use ($rest) {
+    // Get Customer General Info
+    $rest->get('/:id', function ($id) use ($rest) {
+        $rest->customers->getById($rest, $id);
+    });
+    // All Customers
+    $rest->get('/', function () use ($rest) {
+        $rest->customers->get($rest);
+    });
+    // Add Customer
+    $rest->post('/', function () use ($rest) {
+        $rest->customers->post($rest);
+    });
+    // Edit Customer
+    $rest->put('/:id', function ($id) use ($rest) {
+        $rest->customers->put($rest, $id);
+    });
+    // Delete Customer
+    $rest->delete('/:id', function ($id) use ($rest) {
+        $rest->customers->delete($rest, $id);
+    });
+    // Get Customer Branches
+    $rest->get('/:id/branches/', function ($id) use ($rest) {
+        $rest->customers->getBranches($rest, $id);
+    });
 });
 // ------------------------------- Customers -------------------------------
 
 // ------------------------------- Suppliers -------------------------------
-$rest->container->singleton('suppliers', function() {
-	return new Suppliers();
+$rest->container->singleton('suppliers', function () {
+    return new Suppliers();
 });
-$rest->group('/suppliers', function () use($rest)
-{
-	// All Suppliers
-	$rest->get('/', function () use($rest)
-	{
-		$rest->suppliers->get($rest);
-	});
-	// Get Supplier General Info
-	$rest->get('/:id', function ($id) use($rest)
-	{
-		$rest->suppliers->getById($rest, $id);
-	});
-	// Add Supplier
-	$rest->post('/', function () use($rest)
-	{
-		$rest->suppliers->post($rest);
-	});
-	// Edit Supplier
-	$rest->put('/:id', function ($id) use($rest)
-	{
-		$rest->suppliers->put($rest, $id);
-	});
-	// Delete Supplier
-	$rest->delete('/:id', function ($id) use($rest)
-	{
-		$rest->suppliers->delete($rest, $id);
-	});
-	// Get Supplier Contacts
-	$rest->get('/:id/contacts/', function ($id) use($rest)
-	{
-		$rest->suppliers->getContacts($rest, $id);
-	});
+$rest->group('/suppliers', function () use ($rest) {
+    // All Suppliers
+    $rest->get('/', function () use ($rest) {
+        $rest->suppliers->get($rest);
+    });
+    // Get Supplier General Info
+    $rest->get('/:id', function ($id) use ($rest) {
+        $rest->suppliers->getById($rest, $id);
+    });
+    // Add Supplier
+    $rest->post('/', function () use ($rest) {
+        $rest->suppliers->post($rest);
+    });
+    // Edit Supplier
+    $rest->put('/:id', function ($id) use ($rest) {
+        $rest->suppliers->put($rest, $id);
+    });
+    // Delete Supplier
+    $rest->delete('/:id', function ($id) use ($rest) {
+        $rest->suppliers->delete($rest, $id);
+    });
+    // Get Supplier Contacts
+    $rest->get('/:id/contacts/', function ($id) use ($rest) {
+        $rest->suppliers->getContacts($rest, $id);
+    });
 });
 // ------------------------------- Suppliers -------------------------------
 
 // ------------------------------- Bank Accounts -------------------------------
-$rest->container->singleton('bankAccounts', function() {
-	return new BankAccounts();
+$rest->container->singleton('bankAccounts', function () {
+    return new BankAccounts();
 });
-$rest->group('/bankaccounts', function () use($rest)
-{
-	// Get All Bank Accounts
-	$rest->get('/', function () use($rest)
-	{
-		$rest->bankAccounts->get($rest);
-	});
-	// Get Specific Bank Account
-	$rest->get('/:id', function ($id) use($rest)
-	{
-		$rest->bankAccounts->getById($rest, $id);
-	});
+$rest->group('/bankaccounts', function () use ($rest) {
+    // Get All Bank Accounts
+    $rest->get('/', function () use ($rest) {
+        $rest->bankAccounts->get($rest);
+    });
+    // Get Specific Bank Account
+    $rest->get('/:id', function ($id) use ($rest) {
+        $rest->bankAccounts->getById($rest, $id);
+    });
 });
 // ------------------------------- Bank Accounts -------------------------------
 
 // ------------------------------- GL Accounts -------------------------------
-$rest->container->singleton('glAccounts', function() {
-	return new GLAccounts();
+$rest->container->singleton('glAccounts', function () {
+    return new GLAccounts();
 });
-$rest->group('/glaccounts', function () use($rest)
-{
-	// Get GL Accounts
-	$rest->get('/', function () use($rest)
-	{
-		$rest->glAccounts->get($rest);
-	});
-	// Get Specific GL Account
-	$rest->get('/:id', function ($id) use($rest)
-	{
-		$rest->glAccounts->getById($rest, $id);
-	});
-	// Insert GL Accounts
-	$rest->post('/', function () use($rest)
-	{
-		$rest->glAccounts->post($rest);
-	});
-	// Update GL Accounts
-	$rest->put('/:id', function ($id) use($rest)
-	{
-		$rest->glAccounts->put($rest, $id);
-	});
-	// Delete GL Accounts
-	$rest->delete('/:id', function ($id) use($rest)
-	{
-		$rest->glAccounts->delete($rest, $id);
-	});
+$rest->group('/glaccounts', function () use ($rest) {
+    // Get GL Accounts
+    $rest->get('/', function () use ($rest) {
+        $rest->glAccounts->get($rest);
+    });
+    // Get Specific GL Account
+    $rest->get('/:id', function ($id) use ($rest) {
+        $rest->glAccounts->getById($rest, $id);
+    });
+    // Insert GL Accounts
+    $rest->post('/', function () use ($rest) {
+        $rest->glAccounts->post($rest);
+    });
+    // Update GL Accounts
+    $rest->put('/:id', function ($id) use ($rest) {
+        $rest->glAccounts->put($rest, $id);
+    });
+    // Delete GL Accounts
+    $rest->delete('/:id', function ($id) use ($rest) {
+        $rest->glAccounts->delete($rest, $id);
+    });
 });
 // Get GL Account Types
-$rest->get('/glaccounttypes/', function () use($rest)
-{
-	$rest->glAccounts->getTypes($rest);
+$rest->get('/glaccounttypes/', function () use ($rest) {
+    $rest->glAccounts->getTypes($rest);
 });
 // ------------------------------- GL Accounts -------------------------------
 
 // ------------------------------- Currencies -------------------------------
-$rest->container->singleton('currencies', function() {
-	return new Currencies();
+$rest->container->singleton('currencies', function () {
+    return new Currencies();
 });
-$rest->group('/currencies', function () use($rest)
-{
-	// Get All Currencies
-	$rest->get('/', function () use($rest)
-	{
-		$rest->currencies->get($rest);
-	});
-	// Get Specific Currency
-	$rest->get('/:id', function ($id) use($rest)
-	{
-		$rest->currencies->getById($rest, $id);
-	});
+$rest->group('/currencies', function () use ($rest) {
+    // Get All Currencies
+    $rest->get('/', function () use ($rest) {
+        $rest->currencies->get($rest);
+    });
+    // Get Specific Currency
+    $rest->get('/:id', function ($id) use ($rest) {
+        $rest->currencies->getById($rest, $id);
+    });
 });
 // Get Last Exchange Rate
-$rest->get('/exrates/:curr_abrev', function ($curr_abrev) use($rest)
-{
-	$rest->currencies->getLastExchangeRate($rest, $curr_abrev);
+$rest->get('/exrates/:curr_abrev', function ($curr_abrev) use ($rest) {
+    $rest->currencies->getLastExchangeRate($rest, $curr_abrev);
 });
 // ------------------------------- Currencies -------------------------------
 
 // ------------------------------- Inventory Costs -------------------------------
-$rest->container->singleton('inventoryCosts', function() {
-	return new InventoryCosts();
+$rest->container->singleton('inventoryCosts', function () {
+    return new InventoryCosts();
 });
-$rest->group('/itemcosts', function () use($rest)
-{
-	// Get Item Cost
-	$rest->get('/:id', function ($id) use($rest)
-	{
-		$rest->inventoryCosts->getById($rest, $id);
-	});
-	// Update Item Cost
-	$rest->put('/:id', function ($id) use($rest)
-	{
-		$rest->inventoryCosts->put($rest, $id);
-	});
+$rest->group('/itemcosts', function () use ($rest) {
+    // Get Item Cost
+    $rest->get('/:id', function ($id) use ($rest) {
+        $rest->inventoryCosts->getById($rest, $id);
+    });
+    // Update Item Cost
+    $rest->put('/:id', function ($id) use ($rest) {
+        $rest->inventoryCosts->put($rest, $id);
+    });
 });
 // ------------------------------- Inventory Costs -------------------------------
 
@@ -422,109 +356,93 @@ $rest->group('/itemcosts', function () use($rest)
 // Fixed Assets
 function assets_supported()
 {
-	global $path_to_root;
-	return file_exists($path_to_root . '/modules/asset_register');
+    global $path_to_root;
+    return file_exists($path_to_root . '/modules/asset_register');
 }
 if (assets_supported()) {
-	// Get Fixed Asset
-	$rest->get('/assets/:id', function ($id) use($rest)
-	{
-		include_once (API_ROOT . "/assets.inc");
-		assets_get($id);
-	});
-	// Insert Fixed Asset
-	$rest->post('/assets/', function () use($rest)
-	{
-		include_once (API_ROOT . "/assets.inc");
-		assets_add();
-	});
-	// Get Asset Types
-	$rest->get('/assettypes/', function () use($rest)
-	{
-		global $req;
-		include_once (API_ROOT . "/assets.inc");
+    // Get Fixed Asset
+    $rest->get('/assets/:id', function ($id) use ($rest) {
+        include_once(API_ROOT . "/assets.inc");
+        assets_get($id);
+    });
+    // Insert Fixed Asset
+    $rest->post('/assets/', function () use ($rest) {
+        include_once(API_ROOT . "/assets.inc");
+        assets_add();
+    });
+    // Get Asset Types
+    $rest->get('/assettypes/', function () use ($rest) {
+        global $req;
+        include_once(API_ROOT . "/assets.inc");
 
-		$page = $req->get("page");
+        $page = $req->get("page");
 
-		if ($page == null) {
-			assettypes_all();
-		} else {
-			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
-			$from = -- $page * RESULTS_PER_PAGE;
-			assettypes_all($from);
-		}
-	});
+        if ($page == null) {
+            assettypes_all();
+        } else {
+            // If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+            $from = -- $page * RESULTS_PER_PAGE;
+            assettypes_all($from);
+        }
+    });
 }
 // ------------------------------- Assets -------------------------------
 
 // ------------------------------- Sales --------------------------------
-$rest->container->singleton('sales', function() {
-	return new Sales();
+$rest->container->singleton('sales', function () {
+    return new Sales();
 });
-$rest->group('/sales', function () use($rest)
-{
-	// Get Sales Header and Details
-	$rest->get('/:trans_no/:trans_type', function ($trans_no, $trans_type) use($rest)
-	{
-		$rest->sales->getById($rest, $trans_no, $trans_type);
-	});
-	// Insert Sales
-	$rest->post('/', function () use($rest)
-	{
-		$rest->sales->post($rest);
-	});
-	// Edit Sales
-	$rest->put('/:trans_no/:trans_type', function ($trans_no, $trans_type) use($rest)
-	{
-		$rest->sales->put($rest, $trans_no, $trans_type);
-	});
-	// Cancel Sales
-	$rest->delete('/:branch_id/:uuid', function ($branch_id, $uuid) use($rest)
-	{
-		$rest->sales->delete($rest, $branch_id, $uuid);
-	});
-	// All Sales
-	$rest->get('/:trans_type/', function ($trans_type) use($rest)
-	{
-		$rest->sales->get($rest, $trans_type);
-	});
+$rest->group('/sales', function () use ($rest) {
+    // Get Sales Header and Details
+    $rest->get('/:trans_no/:trans_type', function ($trans_no, $trans_type) use ($rest) {
+        $rest->sales->getById($rest, $trans_no, $trans_type);
+    });
+    // Insert Sales
+    $rest->post('/', function () use ($rest) {
+        $rest->sales->post($rest);
+    });
+    // Edit Sales
+    $rest->put('/:trans_no/:trans_type', function ($trans_no, $trans_type) use ($rest) {
+        $rest->sales->put($rest, $trans_no, $trans_type);
+    });
+    // Cancel Sales
+    $rest->delete('/:branch_id/:uuid', function ($branch_id, $uuid) use ($rest) {
+        $rest->sales->delete($rest, $branch_id, $uuid);
+    });
+    // All Sales
+    $rest->get('/:trans_type/', function ($trans_type) use ($rest) {
+        $rest->sales->get($rest, $trans_type);
+    });
 });
 // ------------------------------- Sales --------------------------------
-// ---------------------------- Dimensions ------------------------------
-$rest->container->singleton('dimensions', function() {
-	return new Dimensions();
+
+// ----------------------------- Dimensions -----------------------------
+$rest->container->singleton('dimensions', function () {
+    return new Dimensions();
 });
-$rest->group('/dimensions', function () use($rest)
-{
-	// Get Dimension
-	$rest->get('/:ref', function ($ref) use($rest)
-	{
-		$rest->dimensions->getById($rest, $ref);
-	});
-	// Insert Dimension
-	$rest->post('/', function () use($rest)
-	{
-		$rest->dimensions->post($rest);
-	});
-	// Edit Dimension
-	$rest->put('/:ref', function ($ref) use($rest)
-	{
-		$rest->dimensions->put($rest, $ref);
-	});
-	// Delete Dimension
-	$rest->delete('/:ref', function ($ref) use($rest)
-	{
-		$rest->dimensions->delete($rest, $ref);
-	});
-	// All Dimensions
-	$rest->get('/', function () use($rest)
-	{
-		$rest->dimensions->get($rest);
-	});
+$rest->group('/dimensions', function () use ($rest) {
+    // Get Dimension
+    $rest->get('/:ref', function ($ref) use ($rest) {
+        $rest->dimensions->getById($rest, $ref);
+    });
+    // Insert Dimension
+    $rest->post('/', function () use ($rest) {
+        $rest->dimensions->post($rest);
+    });
+    // Edit Dimension
+    $rest->put('/:ref', function ($ref) use ($rest) {
+        $rest->dimensions->put($rest, $ref);
+    });
+    // Delete Dimension
+    $rest->delete('/:ref', function ($ref) use ($rest) {
+        $rest->dimensions->delete($rest, $ref);
+    });
+    // All Dimensions
+    $rest->get('/', function () use ($rest) {
+        $rest->dimensions->get($rest);
+    });
 });
-// ---------------------------- Dimensions ------------------------------
+// ----------------------------- Dimensions -----------------------------
 
 // Init API
 $rest->run();
-
-?>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "GPL V3",
   "devDependencies": {
     "async": "~0.9.0",
-    "gulp": "~3.8",
+    "gulp": "~3.9",
     "gulp-git": "~0.5.0",
     "gulp-livereload": "~1.2.0",
     "gulp-rename": "~1.2.0",

--- a/src/BankAccounts.php
+++ b/src/BankAccounts.php
@@ -71,7 +71,7 @@ class BankAccounts
      * @SWG\Get(
      *   path="/bankaccounts",
      *   summary="List Bank Accounts",
-     *   tags={"bank account"},
+     *   tags={"bankaccounts"},
      *   operationId="listBankAccounts",
      *   produces={"application/json"},
      *   @SWG\Response(
@@ -104,7 +104,7 @@ class BankAccounts
      * @SWG\Get(
      *   path="/bankaccounts/{id}",
      *   summary="Get Bank Account by id",
-     *   tags={"bank account"},
+     *   tags={"bankaccounts"},
      *   operationId="getBankAccount",
      *   produces={"application/json"},
      *   @SWG\Parameter(

--- a/src/BankAccounts.php
+++ b/src/BankAccounts.php
@@ -3,7 +3,8 @@ namespace FAAPI;
 
 $path_to_root = "../..";
 
-include_once ($path_to_root . "/gl/includes/db/gl_db_bank_accounts.inc");
+include_once($path_to_root . "/gl/includes/db/gl_db_bank_accounts.inc");
+
 /**
  * @SWG\Definition(
  *   definition="BankAccount",
@@ -11,81 +12,56 @@ include_once ($path_to_root . "/gl/includes/db/gl_db_bank_accounts.inc");
  *   format="",
  *   description="A Bank Account",
  *   @SWG\Property(
- *     property="id",
- *     type="integer",
- *     description="Unique id used to reference a Bank Account",
- *     example="1"
+ *     property="id", type="integer", example="1",
+ *     description="Unique id used to reference a Bank Account"
  *   ),
  *   @SWG\Property(
- *     property="account_code",
- *     type="string",
- *     description="Account GL code",
- *     example="1060"
+ *     property="account_code", type="string", example="1060",
+ *     description="Account GL code"
  *   ),
  *   @SWG\Property(
- *     property="account_type",
- *     type="integer",
- *     description="Type of the account",
- *     example="0"
+ *     property="account_type", type="integer", example="0",
+ *     description="Type of the account"
  *   ),
  *   @SWG\Property(
- *     property="bank_name",
- *     type="string",
- *     description="Name of the bank at which this account is held",
- *     example="Some Bank"
+ *     property="bank_name", type="string", example="Some Bank",
+ *     description="Name of the bank at which this account is held"
  *   ),
  *   @SWG\Property(
- *     property="bank_address",
- *     type="string",
+ *     property="bank_address", type="string",
  *     description="Address of the Bank"
  *   ),
  *   @SWG\Property(
- *     property="bank_account_name",
- *     type="string",
- *     description="Name of the account",
- *     example="Anne X Ample"
+ *     property="bank_account_name", type="string", example="Anne X Ample",
+ *     description="Name of the account"
  *   ),
  *   @SWG\Property(
- *     property="bank_account_number",
- *     type="string",
- *     description="Account number used by the Bank",
- *     example="12-3456-7890-1"
+ *     property="bank_account_number", type="string", example="12-3456-789123-00",
+ *     description="Account number used by the Bank"
  *   ),
  *   @SWG\Property(
- *     property="bank_curr_code",
- *     type="string",
- *     description="Currency of the account",
- *     example="USD"
+ *     property="bank_curr_code", type="string", example="USD",
+ *     description="Currency of the account"
  *   ),
  *   @SWG\Property(
- *     property="dflt_curr_act",
- *     type="boolean",
- *     description="True (1) if this account is the default account",
- *     example="0"
+ *     property="dflt_curr_act", type="boolean", example="0",
+ *     description="True (1) if this account is the default account"
  *   ),
  *   @SWG\Property(
- *     property="bank_charge_act",
- *     type="string",
- *     description="GL account to which bank charges are assigned",
- *     example="5690"
+ *     property="bank_charge_act", type="string", example="5690",
+ *     description="GL account to which bank charges are assigned"
  *   ),
  *   @SWG\Property(
- *     property="last_reconciled_date",
- *     type="date",
- *     description="Date up to which this account was reconciled",
- *     example="2017-12-01"
+ *     property="last_reconciled_date", type="date", example="2017-12-01",
+ *     description="Date up to which this account was reconciled"
  *   ),
  *   @SWG\Property(
- *     property="ending_reconcile_balance",
- *     type="number",
- *     description="Account balance at last reconcile",
- *     example="12.34"
+ *     property="ending_reconcile_balance", type="number", example="12.34",
+ *     description="Account balance at last reconcile"
  *   ),
  *   @SWG\Property(
- *     property="inactive",
- *     type="boolean",
- *     description="True if this account is not active",
- *     example="0"
+ *     property="inactive", type="boolean", example="0",
+ *     description="True if this account is not active"
  *   )
  * )
  */
@@ -93,20 +69,20 @@ class BankAccounts
 {
     /**
      * @SWG\Get(
-     *     path="/bankaccounts",
-     *     summary="List Bank Accounts",
-     *     tags={"bank account"},
-     *     operationId="listBankAccounts",
-     *     produces={"application/json"},
-     *     @SWG\Response(
-     *         response=200,
-     *         description="successful operation",
-     *         @SWG\Schema(
-     *             type="array",
-     *             @SWG\Items(ref="#/definitions/BankAccount")
-     *         )
-     *     ),
-     *     deprecated=false
+     *   path="/bankaccounts",
+     *   summary="List Bank Accounts",
+     *   tags={"bank account"},
+     *   operationId="listBankAccounts",
+     *   produces={"application/json"},
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="array",
+     *       @SWG\Items(ref="#/definitions/BankAccount")
+     *     )
+     *   ),
+     *   deprecated=false
      * )
      */
     public function get($rest)
@@ -126,20 +102,27 @@ class BankAccounts
 
     /**
      * @SWG\Get(
-     *     path="/bankaccounts/id",
-     *     summary="Fetch Bank Account by id",
-     *     tags={"bank account"},
-     *     operationId="getBankAccount",
-     *     produces={"application/json"},
-     *     @SWG\Response(
-     *         response=200,
-     *         description="successful operation",
-     *         @SWG\Schema(
-     *             type="object",
-     *             ref="#/definitions/BankAccount"
-     *         )
-     *     ),
-     *     deprecated=false
+     *   path="/bankaccounts/{id}",
+     *   summary="Get Bank Account by id",
+     *   tags={"bank account"},
+     *   operationId="getBankAccount",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     description="ID of Bank Account to return",
+     *     in="path",
+     *     name="bankAccountId",
+     *     required=true,
+     *     type="string"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="object",
+     *       ref="#/definitions/BankAccount"
+     *     )
+     *   ),
+     *   deprecated=false
      * )
      */
     public function getById($rest, $id)
@@ -148,16 +131,175 @@ class BankAccounts
         api_success_response(json_encode(\api_ensureAssociativeArray($bank)));
     }
 
+    /**
+     * @SWG\Post(
+     *   path="/bankaccounts",
+     *   summary="Add Bank Account",
+     *   tags={"bankaccounts"},
+     *   operationId="addBankAccount",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="body",
+     *     in="body",
+     *     description="Bank Account to be added",
+     *     required=true,
+     *     @SWG\Schema(ref="#/definitions/BankAccount"),
+     *   ),
+     *   @SWG\Response(
+     *     response=201,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="object",
+     *       @SWG\Property(property="account_code", type="string")
+     *     )
+     *   ),
+     *   deprecated=false
+     * )
+     */
+    public function post($rest)
+    {
+        $req = $rest->request();
+        $model = $req->post();
+        \api_validate('account_code', $model);
+        \api_validate('account_type', $model);
+        \api_validate('bank_account_name', $model);
+        \api_validate('bank_account_number', $model);
+        \api_validate('bank_curr_code', $model);
+        \api_check('bank_name', $model);
+        \api_check('bank_address', $model);
+        \api_check('dflt_curr_act', $model);
+        \api_check('bank_charge_act', $model);
+        \api_check('inactive', $model, '0');
+
+        // add_bank_account($account_code, $account_type, $bank_account_name,
+        //     $bank_name, $bank_account_number, $bank_address, $bank_curr_code, 
+        //     $dflt_curr_act, $bank_charge_act
+        // )
+        add_bank_account($model['account_code'], $model['account_type'], $model['bank_account_name'],
+            $model['bank_name'], $model['bank_account_number'], $model['bank_address'], $model['bank_curr_code'], 
+            $model['dflt_curr_act'], $model['bank_charge_act']
+        );
+        // add_bank_account does not return the newly inserted id, therefore
+        // we query based on the account_code which *should* be unique even
+        // though the database schema (as of 2.4.4) doesn't enforce this.
+        $sql = "SELECT id, account_code FROM " . TB_PREF . "bank_accounts WHERE account_code=" . db_escape($model['account_code']);
+        $result = db_query($sql, "Cannot query bank_accounts");
+        $count = db_num_rows($result);
+        if ($count == 0) {
+            \api_error(502, sprintf("Could not add '%s'", db_escape($model['account_code'])));
+        }
+        if ($count > 1) {
+            \api_error(502, sprintf("Multiple accounts exist for '%s'", db_escape($model['account_code'])));
+        }
+        $row = db_fetch_assoc($result);
+        \api_create_response(array('id' => $row['id']));
+    }
+
+    /**
+     * @SWG\Put(
+     *   path="/bankaccounts/{id}",
+     *   summary="Update Bank Account",
+     *   tags={"bankaccounts"},
+     *   operationId="updateBankAccount",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     description="ID of Bank Account to update",
+     *     in="path",
+     *     name="bankAccountId",
+     *     required=true,
+     *     type="string"
+     *   ),
+     *   @SWG\Parameter(
+     *     name="body",
+     *     in="body",
+     *     description="Bank Account to be updated",
+     *     required=true,
+     *     @SWG\Schema(ref="#/definitions/BankAccount"),
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="object",
+     * 	     @SWG\Property(property="account_code", type="string")
+     *     )
+     *   ),
+     *   deprecated=false
+     * )
+     */
+    public function put($rest, $id)
+    {
+        $req = $rest->request();
+        $model = $req->post();
+
+        $existing = get_bank_account($id);
+
+        \api_check('account_code', $model, $existing);
+        \api_check('account_type', $model, $existing);
+        \api_check('bank_account_name', $model, $existing);
+        \api_check('bank_account_number', $model, $existing);
+        \api_check('bank_curr_code', $model, $existing);
+        \api_check('bank_name', $model, $existing);
+        \api_check('bank_address', $model, $existing);
+        \api_check('dflt_curr_act', $model, $existing);
+        \api_check('bank_charge_act', $model, $existing);
+        \api_check('inactive', $model, $existing);
+
+        // TODO: inactive not supported for update CP 2018-06
+
+        // FA 2.4.4 function prototype
+        // update_bank_account($id, $account_code, $account_type, $bank_account_name, 
+        // $bank_name, $bank_account_number, $bank_address, $bank_curr_code, $dflt_curr_act, $bank_charge_act)
+        update_bank_account(
+            $id, $model['account_code'], $model['account_type'], $model['bank_account_name'], 
+            $model['bank_name'], $model['bank_account_number'], $model['bank_address'], $model['bank_curr_code'], $model['dflt_curr_act'], $model['bank_charge_act']
+        );
+
+        \api_success_response(array('id' => $id));
+    }
+
+    /**
+     * @SWG\Delete(
+     *   path="/bankaccounts/{id}",
+     *   summary="Delete Bank Account",
+     *   tags={"bankaccounts"},
+     *   operationId="deleteBankAccount",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     description="ID of Bank Account to delete",
+     *     in="path",
+     *     name="bankAccountId",
+     *     required=true,
+     *     type="string"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *   ),
+     *   deprecated=false
+     * )
+     */
+    public function delete($rest, $id)
+    {
+        $req = $rest->request();
+        $info = $req->post();
+
+        delete_bank_account($id);
+
+        \api_success_response(array('msg' => 'deleted', 'id' => $id));
+    }
+
     private function bankaccounts_all($from = null)
     {
         if ($from == null) {
             $from = 0;
         }
-        $sql = "SELECT * FROM " . TB_PREF . "bank_accounts LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+
+        // TODO Paging doesn't work CP 2018-06
+        // $sql = "SELECT * FROM " . TB_PREF . "bank_accounts LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+        $sql = "SELECT * FROM " . TB_PREF . "bank_accounts";
         $query = db_query($sql, "error");
-
         $info = array();
-
         while ($data = db_fetch($query, "error")) {
             $info[] = array(
                 "id" => $data["id"],

--- a/src/BankAccounts.php
+++ b/src/BankAccounts.php
@@ -4,55 +4,177 @@ namespace FAAPI;
 $path_to_root = "../..";
 
 include_once ($path_to_root . "/gl/includes/db/gl_db_bank_accounts.inc");
-
+/**
+ * @SWG\Definition(
+ *   definition="BankAccount",
+ *   type="object",
+ *   format="",
+ *   description="A Bank Account",
+ *   @SWG\Property(
+ *     property="id",
+ *     type="integer",
+ *     description="Unique id used to reference a Bank Account",
+ *     example="1"
+ *   ),
+ *   @SWG\Property(
+ *     property="account_code",
+ *     type="string",
+ *     description="Account GL code",
+ *     example="1060"
+ *   ),
+ *   @SWG\Property(
+ *     property="account_type",
+ *     type="integer",
+ *     description="Type of the account",
+ *     example="0"
+ *   ),
+ *   @SWG\Property(
+ *     property="bank_name",
+ *     type="string",
+ *     description="Name of the bank at which this account is held",
+ *     example="Some Bank"
+ *   ),
+ *   @SWG\Property(
+ *     property="bank_address",
+ *     type="string",
+ *     description="Address of the Bank"
+ *   ),
+ *   @SWG\Property(
+ *     property="bank_account_name",
+ *     type="string",
+ *     description="Name of the account",
+ *     example="Anne X Ample"
+ *   ),
+ *   @SWG\Property(
+ *     property="bank_account_number",
+ *     type="string",
+ *     description="Account number used by the Bank",
+ *     example="12-3456-7890-1"
+ *   ),
+ *   @SWG\Property(
+ *     property="bank_curr_code",
+ *     type="string",
+ *     description="Currency of the account",
+ *     example="USD"
+ *   ),
+ *   @SWG\Property(
+ *     property="dflt_curr_act",
+ *     type="boolean",
+ *     description="True (1) if this account is the default account",
+ *     example="0"
+ *   ),
+ *   @SWG\Property(
+ *     property="bank_charge_act",
+ *     type="string",
+ *     description="GL account to which bank charges are assigned",
+ *     example="5690"
+ *   ),
+ *   @SWG\Property(
+ *     property="last_reconciled_date",
+ *     type="date",
+ *     description="Date up to which this account was reconciled",
+ *     example="2017-12-01"
+ *   ),
+ *   @SWG\Property(
+ *     property="ending_reconcile_balance",
+ *     type="number",
+ *     description="Account balance at last reconcile",
+ *     example="12.34"
+ *   ),
+ *   @SWG\Property(
+ *     property="inactive",
+ *     type="boolean",
+ *     description="True if this account is not active",
+ *     example="0"
+ *   )
+ * )
+ */
 class BankAccounts
 {
-	// Get Items
-	public function get($rest)
-	{
-		$req = $rest->request();
+    // Get Items
+    /**
+     * @SWG\Get(
+     *     path="/bankaccounts",
+     *     summary="List Bank Accounts",
+     *     tags={"bank account"},
+     *     operationId="listBankAccounts",
+     *     produces={"application/json"},
+     *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="array",
+     *             @SWG\Items(ref="#/definitions/BankAccount")
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
+    public function get($rest)
+    {
+        $req = $rest->request();
 
-		$page = $req->get("page");
+        $page = $req->get("page");
 
-		if ($page == null) {
-			$this->bankaccounts_all();
-		} else {
-			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
-			$from = -- $page * RESULTS_PER_PAGE;
-			$this->bankaccounts_all($from);
-		}
-	}
+        if ($page == null) {
+            $this->bankaccounts_all();
+        } else {
+            // If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+            $from = -- $page * RESULTS_PER_PAGE;
+            $this->bankaccounts_all($from);
+        }
+    }
 
-	// Get Specific Item by Stock Id
-	public function getById($rest, $id)
-	{
-		$bank = get_bank_account($id);
-		api_success_response(json_encode(\api_ensureAssociativeArray($bank)));
-	}
+    // Get Specific Item by Stock Id
+    /**
+     * @SWG\Get(
+     *     path="/bankaccounts/id",
+     *     summary="Fetch Bank Account by id",
+     *     tags={"bank account"},
+     *     operationId="getBankAccount",
+     *     produces={"application/json"},
+     *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="object",
+     *             ref="#/definitions/BankAccount"
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
+    public function getById($rest, $id)
+    {
+        $bank = get_bank_account($id);
+        api_success_response(json_encode(\api_ensureAssociativeArray($bank)));
+        }
+    }
 
-	private function bankaccounts_all($from = null)
-	{
-		if ($from == null)
-			$from = 0;
-		$sql = "SELECT * FROM " . TB_PREF . "bank_accounts LIMIT " . $from . ", " . RESULTS_PER_PAGE;
-		$query = db_query($sql, "error");
+    private function bankaccounts_all($from = null)
+    {
+        if ($from == null) {
+            $from = 0;
+        }
+        $sql = "SELECT * FROM " . TB_PREF . "bank_accounts LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+        $query = db_query($sql, "error");
 
-		$info = array();
+        $info = array();
 
-		while ($data = db_fetch($query, "error")) {
-			$info[] = array(
-				"id" => $data["id"],
-				"account_type" => $data["account_type"],
-				"account_code" => $data["account_code"],
-				"bank_account_name" => $data["bank_account_name"],
-				"bank_name" => $data["bank_name"],
-				"bank_account_number" => $data["bank_account_number"],
-				"bank_curr_code" => $data["bank_curr_code"],
-				"bank_address" => $data["bank_address"],
-				"dflt_curr_act" => $data["dflt_curr_act"]
-			);
-		}
+        while ($data = db_fetch($query, "error")) {
+            $info[] = array(
+                "id" => $data["id"],
+                "account_type" => $data["account_type"],
+                "account_code" => $data["account_code"],
+                "bank_account_name" => $data["bank_account_name"],
+                "bank_name" => $data["bank_name"],
+                "bank_account_number" => $data["bank_account_number"],
+                "bank_curr_code" => $data["bank_curr_code"],
+                "bank_address" => $data["bank_address"],
+                "dflt_curr_act" => $data["dflt_curr_act"]
+            );
+        }
 
-		api_success_response(json_encode($info));
-	}
+        api_success_response(json_encode($info));
+    }
 }

--- a/src/BankAccounts.php
+++ b/src/BankAccounts.php
@@ -91,7 +91,6 @@ include_once ($path_to_root . "/gl/includes/db/gl_db_bank_accounts.inc");
  */
 class BankAccounts
 {
-    // Get Items
     /**
      * @SWG\Get(
      *     path="/bankaccounts",

--- a/src/BankAccounts.php
+++ b/src/BankAccounts.php
@@ -125,7 +125,6 @@ class BankAccounts
         }
     }
 
-    // Get Specific Item by Stock Id
     /**
      * @SWG\Get(
      *     path="/bankaccounts/id",
@@ -148,7 +147,6 @@ class BankAccounts
     {
         $bank = get_bank_account($id);
         api_success_response(json_encode(\api_ensureAssociativeArray($bank)));
-        }
     }
 
     private function bankaccounts_all($from = null)

--- a/src/Category.php
+++ b/src/Category.php
@@ -3,210 +3,213 @@ namespace FAAPI;
 
 $path_to_root = "../..";
 
-include_once ($path_to_root . "/inventory/includes/db/items_category_db.inc");
+include_once($path_to_root . "/inventory/includes/db/items_category_db.inc");
 
 class Category
 {
-	// Get Items
-	public function get($rest)
-	{
-		$req = $rest->request();
+    // Get Items
+    public function get($rest)
+    {
+        $req = $rest->request();
 
-		$page = $req->get("page");
+        $page = $req->get("page");
 
-		if ($page == null) {
-			$this->category_all(null);
-		} else {
-			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
-			$from = -- $page * RESULTS_PER_PAGE;
-			$this->category_all($from);
-		}
-	}
+        if ($page == null) {
+            $this->category_all(null);
+        } else {
+            // If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+            $from = -- $page * RESULTS_PER_PAGE;
+            $this->category_all($from);
+        }
+    }
 
-	// Get Specific Item by Stock Id
-	public function getById($rest, $id)
-	{
-		$catego = get_item_category($id);
-		api_success_response(json_encode(api_ensureAssociativeArray($catego)));
-	}
+    // Get Specific Item by Stock Id
+    public function getById($rest, $id)
+    {
+        $catego = get_item_category($id);
+        api_success_response(json_encode(api_ensureAssociativeArray($catego)));
+    }
 
-	// Add Item
-	public function post($rest)
-	{
-		$req = $rest->request();
-		$info = $req->post();
+    // Add Item
+    public function post($rest)
+    {
+        $req = $rest->request();
+        $info = $req->post();
 
-		// Validate Required Fields
-		if(!isset($info['description'])){
-			api_error(412, 'Description is required');
-		}
-		if(!isset($info['dflt_tax_type'])){
-			api_error(412, 'Tax Type is required');
-		}
-		if(!isset($info['dflt_units'])){
-			api_error(412, 'Units is required');
-		}
-		if(!isset($info['dflt_mb_flag'])){
-			api_error(412, 'MB Flag is required');
-		}
-		if(!isset($info['dflt_sales_act'])){
-			api_error(412, 'Sales Account is required');
-		}
-		if(!isset($info['dflt_cogs_act'])){
-			api_error(412, 'Cogs Account is required');
-		}
-		if(!isset($info['dflt_inventory_act'])){
-			api_error(412, 'Inventory Account is required');
-		}
-		if(!isset($info['dflt_adjustment_act'])){
-			api_error(412, 'Adjustment Account is required');
-		}
-		if(!isset($info['dflt_wip_act'])){
-			api_error(412, 'WIP Account is required');
-		}
+        // Validate Required Fields
+        if (!isset($info['description'])) {
+            api_error(412, 'Description is required');
+        }
+        if (!isset($info['dflt_tax_type'])) {
+            api_error(412, 'Tax Type is required');
+        }
+        if (!isset($info['dflt_units'])) {
+            api_error(412, 'Units is required');
+        }
+        if (!isset($info['dflt_mb_flag'])) {
+            api_error(412, 'MB Flag is required');
+        }
+        if (!isset($info['dflt_sales_act'])) {
+            api_error(412, 'Sales Account is required');
+        }
+        if (!isset($info['dflt_cogs_act'])) {
+            api_error(412, 'Cogs Account is required');
+        }
+        if (!isset($info['dflt_inventory_act'])) {
+            api_error(412, 'Inventory Account is required');
+        }
+        if (!isset($info['dflt_adjustment_act'])) {
+            api_error(412, 'Adjustment Account is required');
+        }
+        if (!isset($info['dflt_wip_act'])) {
+            api_error(412, 'WIP Account is required');
+        }
 
-		/*
-		$description, $tax_type_id, $sales_account,
-		$cogs_account, $inventory_account, $adjustment_account, $wip_account,
-		$units, $mb_flag, $dim1, $dim2, $no_sale
-		*/
-		add_item_category($info['description'], $info['dflt_tax_type'],
-			$info['dflt_sales_act'],
-			$info['dflt_cogs_act'],
-			$info['dflt_inventory_act'],
-			$info['dflt_adjustment_act'],
-			$info['dflt_wip_act'],
-			$info['dflt_units'],
-			$info['dflt_mb_flag'],
-			0, // dimension 1
-			0, // dimension2
-			0, // no sale
-			0  // no purchase
-		);
+        /*
+        $description, $tax_type_id, $sales_account,
+        $cogs_account, $inventory_account, $adjustment_account, $wip_account,
+        $units, $mb_flag, $dim1, $dim2, $no_sale
+        */
+        add_item_category(
+            $info['description'],
+            $info['dflt_tax_type'],
+            $info['dflt_sales_act'],
+            $info['dflt_cogs_act'],
+            $info['dflt_inventory_act'],
+            $info['dflt_adjustment_act'],
+            $info['dflt_wip_act'],
+            $info['dflt_units'],
+            $info['dflt_mb_flag'],
+            0, // dimension 1
+            0, // dimension2
+            0, // no sale
+            0  // no purchase
+        );
 
-		$id = db_insert_id();
-		$catego = get_item_category($id);
+        $id = db_insert_id();
+        $catego = get_item_category($id);
 
-		if($catego != null){
-			api_create_response(json_encode($catego));
-		}else {
-			api_error(500, 'Could Not Save to Database');
-		}
-	}
-	// Edit Specific Item
-	public function put($rest, $id)
-	{
-		$req = $rest->request();
-		$info = $req->post();
+        if ($catego != null) {
+            api_create_response(json_encode($catego));
+        } else {
+            api_error(500, 'Could Not Save to Database');
+        }
+    }
+    // Edit Specific Item
+    public function put($rest, $id)
+    {
+        $req = $rest->request();
+        $info = $req->post();
 
-		$catego = get_item_category($id);
-		if($catego == null){
-			api_error(400, 'Invalid Category ID');
-		}
+        $catego = get_item_category($id);
+        if ($catego == null) {
+            api_error(400, 'Invalid Category ID');
+        }
 
-		// Validate Required Fields
-		if(!isset($info['description'])){
-			api_error(412, 'Description is required');
-		}
-		if(!isset($info['dflt_tax_type'])){
-			api_error(412, 'Tax Type is required');
-		}
-		if(!isset($info['dflt_units'])){
-			api_error(412, 'Units is required');
-		}
-		if(!isset($info['dflt_mb_flag'])){
-			api_error(412, 'MB Flag is required');
-		}
-		if(!isset($info['dflt_sales_act'])){
-			api_error(412, 'Sales Account is required');
-		}
-		if(!isset($info['dflt_cogs_act'])){
-			api_error(412, 'Cogs Account is required');
-		}
-		if(!isset($info['dflt_inventory_act'])){
-			api_error(412, 'Inventory Account is required');
-		}
-		if(!isset($info['dflt_adjustment_act'])){
-			api_error(412, 'Adjustment Account is required');
-		}
-		if(!isset($info['dflt_wip_act'])){
-			api_error(412, 'Assembly Account is required');
-		}
+        // Validate Required Fields
+        if (!isset($info['description'])) {
+            api_error(412, 'Description is required');
+        }
+        if (!isset($info['dflt_tax_type'])) {
+            api_error(412, 'Tax Type is required');
+        }
+        if (!isset($info['dflt_units'])) {
+            api_error(412, 'Units is required');
+        }
+        if (!isset($info['dflt_mb_flag'])) {
+            api_error(412, 'MB Flag is required');
+        }
+        if (!isset($info['dflt_sales_act'])) {
+            api_error(412, 'Sales Account is required');
+        }
+        if (!isset($info['dflt_cogs_act'])) {
+            api_error(412, 'Cogs Account is required');
+        }
+        if (!isset($info['dflt_inventory_act'])) {
+            api_error(412, 'Inventory Account is required');
+        }
+        if (!isset($info['dflt_adjustment_act'])) {
+            api_error(412, 'Adjustment Account is required');
+        }
+        if (!isset($info['dflt_wip_act'])) {
+            api_error(412, 'Assembly Account is required');
+        }
 
-		/*
-		$id, $description, $tax_type_id,
-		$sales_account, $cogs_account, $inventory_account, $adjustment_account,
-		$wip_account, $units, $mb_flag, $dim1, $dim2, $no_sale
-		*/
-		update_item_category(
-			$id, $info['description'],
-			$info['dflt_tax_type'],
-			$info['dflt_sales_act'],
-			$info['dflt_cogs_act'],
-			$info['dflt_inventory_act'],
-			$info['dflt_adjustment_act'],
-			$info['dflt_wip_act'],
-			$info['dflt_units'],
-			$info['dflt_mb_flag'],
-			0, // dimension 1
-			0, // dimension2
-			0, // no sale
-			0  // no purchase
-		);
+        /*
+        $id, $description, $tax_type_id,
+        $sales_account, $cogs_account, $inventory_account, $adjustment_account,
+        $wip_account, $units, $mb_flag, $dim1, $dim2, $no_sale
+        */
+        update_item_category(
+            $id,
+            $info['description'],
+            $info['dflt_tax_type'],
+            $info['dflt_sales_act'],
+            $info['dflt_cogs_act'],
+            $info['dflt_inventory_act'],
+            $info['dflt_adjustment_act'],
+            $info['dflt_wip_act'],
+            $info['dflt_units'],
+            $info['dflt_mb_flag'],
+            0, // dimension 1
+            0, // dimension2
+            0, // no sale
+            0  // no purchase
+        );
 
-		api_success_response("Category has been updated");
-	}
-	// Delete Specific Item
-	public function delete($rest, $id)
-	{
-		$req = $rest->request();
-		$info = $req->post();
+        api_success_response("Category has been updated");
+    }
+    // Delete Specific Item
+    public function delete($rest, $id)
+    {
+        $req = $rest->request();
+        $info = $req->post();
 
-		$catego = get_item_category($id);
-		if($catego == null){
-			api_error(400, 'Invalid Category ID');
-		}
+        $catego = get_item_category($id);
+        if ($catego == null) {
+            api_error(400, 'Invalid Category ID');
+        }
 
-		delete_item_category($id);
+        delete_item_category($id);
 
-		$catego = get_item_category($id);
+        $catego = get_item_category($id);
 
-		if($catego != null){
-			api_error(500, 'Could Not Delete from Database: ');
-		}else {
-			api_success_response("Category has been deleted");
-		}
-	}
+        if ($catego != null) {
+            api_error(500, 'Could Not Delete from Database: ');
+        } else {
+            api_success_response("Category has been deleted");
+        }
+    }
 
-	private function category_all($from = null)
-	{
-		$sql = "SELECT c.*, t.name as tax_name FROM "
-			. TB_PREF . "stock_category c, "
-			. TB_PREF . "item_tax_types t WHERE c.dflt_tax_type=t.id";
-		if ($from !== null) {
-			$sql .= "LIMIT " . $from . ", " . RESULTS_PER_PAGE;
-		}
+    private function category_all($from = null)
+    {
+        $sql = "SELECT c.*, t.name as tax_name FROM "
+            . TB_PREF . "stock_category c, "
+            . TB_PREF . "item_tax_types t WHERE c.dflt_tax_type=t.id";
+        if ($from !== null) {
+            $sql .= "LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+        }
 
-		$query = db_query($sql, "error");
+        $query = db_query($sql, "error");
 
-		$info = array();
+        $info = array();
 
-		while ($data = db_fetch($query, "error")) {
-			$info[] = array(
-				'category_id' => $data['category_id'],
-				'description' => $data['description'],
-				'dflt_tax_type' => $data['dflt_tax_type'],
-				'dflt_units' => $data['dflt_units'],
-				'dflt_mb_flag' => $data['dflt_mb_flag'],
-				'dflt_sales_act' => $data['dflt_sales_act'],
-				'dflt_cogs_act' => $data['dflt_cogs_act'],
-				'dflt_inventory_act' => $data['dflt_inventory_act'],
-				'dflt_adjustment_act' => $data['dflt_adjustment_act'],
-				'dflt_wip_act' => $data['dflt_wip_act'],
-				'dflt_no_sale' => $data['dflt_no_sale']
-			);
-		}
+        while ($data = db_fetch($query, "error")) {
+            $info[] = array(
+                'category_id' => $data['category_id'],
+                'description' => $data['description'],
+                'dflt_tax_type' => $data['dflt_tax_type'],
+                'dflt_units' => $data['dflt_units'],
+                'dflt_mb_flag' => $data['dflt_mb_flag'],
+                'dflt_sales_act' => $data['dflt_sales_act'],
+                'dflt_cogs_act' => $data['dflt_cogs_act'],
+                'dflt_inventory_act' => $data['dflt_inventory_act'],
+                'dflt_adjustment_act' => $data['dflt_adjustment_act'],
+                'dflt_wip_act' => $data['dflt_wip_act'],
+                'dflt_no_sale' => $data['dflt_no_sale']
+            );
+        }
 
-		api_success_response(json_encode($info));
-	}
+        api_success_response(json_encode($info));
+    }
 }

--- a/src/Currencies.php
+++ b/src/Currencies.php
@@ -3,86 +3,87 @@ namespace FAAPI;
 
 $path_to_root = "../..";
 
-include_once ($path_to_root . "/gl/includes/db/gl_db_currencies.inc");
-// include_once($path_to_root . "/gl/includes/db/gl_db_rates.inc");
-include_once ($path_to_root . "/includes/banking.inc");
+include_once($path_to_root . "/gl/includes/db/gl_db_currencies.inc");
+include_once($path_to_root . "/includes/banking.inc");
 
 class Currencies
 {
-	// Get Items
-	public function get($rest)
-	{
-		$req = $rest->request();
+    // Get Items
+    public function get($rest)
+    {
+        $req = $rest->request();
 
-		$page = $req->get("page");
+        $page = $req->get("page");
 
-		if ($page == null) {
-			$this->currencies_all();
-		} else {
-			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
-			$from = -- $page * RESULTS_PER_PAGE;
-			$this->currencies_all($from);
-		}
-	}
+        if ($page == null) {
+            $this->currencies_all();
+        } else {
+            // If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+            $from = -- $page * RESULTS_PER_PAGE;
+            $this->currencies_all($from);
+        }
+    }
 
-	// Get Specific Item by Stock Id
-	public function getById($rest, $id)
-	{
-		$curr = get_currency($id);
-		if (! $curr)
-			$curr = array();
-		api_success_response(json_encode($curr));
-	}
+    // Get Specific Item by Stock Id
+    public function getById($rest, $id)
+    {
+        $curr = get_currency($id);
+        if (! $curr) {
+            $curr = array();
+        }
+        api_success_response(json_encode($curr));
+    }
 
-	public function getLastExchangeRate($rest, $currencyCode)
-	{
-		$date = date2sql(Today());
+    public function getLastExchangeRate($rest, $currencyCode)
+    {
+        $date = date2sql(Today());
 
-		$sql = "SELECT rate_buy, max(date_) as date_ FROM "
-			. TB_PREF . "exchange_rates WHERE curr_code = " . db_escape($id)
-			. " AND date_ <= '$date' GROUP BY rate_buy ORDER BY date_ Desc LIMIT 1";
+        $sql = "SELECT rate_buy, max(date_) as date_ FROM "
+            . TB_PREF . "exchange_rates WHERE curr_code = " . db_escape($id)
+            . " AND date_ <= '$date' GROUP BY rate_buy ORDER BY date_ Desc LIMIT 1";
 
-		$result = db_query($sql, "could not query exchange rates");
+        $result = db_query($sql, "could not query exchange rates");
 
-		if (db_num_rows($result) == 0) {
-			// no stored exchange rate, just return 0
-			api_success_response(json_encode(array(
-				'curr_abrev' => $id,
-				'rate' => 0,
-				'date' => $date
-			)));
-		}
+        if (db_num_rows($result) == 0) {
+            // no stored exchange rate, just return 0
+            api_success_response(json_encode(array(
+                'curr_abrev' => $id,
+                'rate' => 0,
+                'date' => $date
+            )));
+        }
 
-		$myrow = db_fetch_row($result);
+        $myrow = db_fetch_row($result);
 
-		api_success_response(json_encode(array(
-			'curr_abrev' => $id,
-			'rate' => $myrow[0],
-			'date' => $myrow[1]
-		)));
-	}
+        api_success_response(json_encode(array(
+            'curr_abrev' => $id,
+            'rate' => $myrow[0],
+            'date' => $myrow[1]
+        )));
+    }
 
-	private function currencies_all($from = null)
-	{
-		if ($from == null)
-			$from = 0;
+    private function currencies_all($from = null)
+    {
+        if ($from == null) {
+            $from = 0;
+        }
 
-		$sql = "SELECT * FROM " . TB_PREF . "currencies WHERE !inactive LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+        $sql = "SELECT * FROM " . TB_PREF . "currencies WHERE !inactive LIMIT " . $from . ", " . RESULTS_PER_PAGE;
 
-		$query = db_query($sql, "error");
+        $query = db_query($sql, "error");
 
-		$info = array();
+        $info = array();
 
-		while ($data = db_fetch($query, "error")) {
-			$info[] = array(
-				'curr_abrev' => $data['curr_abrev'],
-				'currency' => $data['currency'],
-				'curr_symbol' => $data['curr_symbol'],
-				'country' => $data['country'],
-				'hundreds_name' => $data['hundreds_name']
-			);
-		}
+        while ($data = db_fetch($query, "error")) {
+            $info[] = array(
+                'curr_abrev' => $data['curr_abrev'],
+                'currency' => $data['currency'],
+                'curr_symbol' => $data['curr_symbol'],
+                'country' => $data['country'],
+                'hundreds_name' => $data['hundreds_name']
+            );
+        }
 
-		api_success_response(json_encode($info));
-	}
+        api_success_response(json_encode($info));
+    }
 }

--- a/src/Customers.php
+++ b/src/Customers.php
@@ -3,279 +3,279 @@ namespace FAAPI;
 
 $path_to_root = "../..";
 
-include_once ($path_to_root . "/sales/includes/db/customers_db.inc");
-include_once ($path_to_root . "/includes/db/crm_contacts_db.inc");
+include_once($path_to_root . "/sales/includes/db/customers_db.inc");
+include_once($path_to_root . "/includes/db/crm_contacts_db.inc");
 
 class Customers
 {
-	// Get Items
-	public function get($rest)
-	{
-		$req = $rest->request();
+    // Get Items
+    public function get($rest)
+    {
+        $req = $rest->request();
 
-		$page = $req->get("page");
+        $page = $req->get("page");
 
-		if ($page == null) {
-			$this->customer_all();
-		} else {
-			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
-			$from = -- $page * RESULTS_PER_PAGE;
-			$this->customer_all($from);
-		}
-	}
+        if ($page == null) {
+            $this->customer_all();
+        } else {
+            // If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+            $from = -- $page * RESULTS_PER_PAGE;
+            $this->customer_all($from);
+        }
+    }
 
-	// Get Specific Item by Stock Id
-	public function getById($rest, $id)
-	{
-		$cust = get_customer($id);
-		api_success_response(json_encode(api_ensureAssociativeArray($cust)));
-	}
-	// Add Item
-	public function post($rest)
-	{
-		$req = $rest->request();
-		$info = $req->post();
+    // Get Specific Item by Stock Id
+    public function getById($rest, $id)
+    {
+        $cust = get_customer($id);
+        api_success_response(json_encode(api_ensureAssociativeArray($cust)));
+    }
+    // Add Item
+    public function post($rest)
+    {
+        $req = $rest->request();
+        $info = $req->post();
 
-		// Validate Required Fields
-		if (! isset($info['name'])) {
-			api_error(412, 'Customer Name is required [name]');
-		}
-		if (! isset($info['debtor_ref'])) {
-			api_error(412, 'Customer Reference is required [debtor_ref]');
-		}
-		if (! isset($info['address'])) {
-			api_error(412, 'Address is required [address]');
-		}
-		if (! isset($info['tax_id'])) {
-			api_error(412, 'Tax Id is required [tax_id]');
-		}
-		if (! isset($info['curr_code'])) {
-			api_error(412, 'Currency Code is required [curr_code]');
-		}
-		if (! isset($info['credit_status'])) {
-			// TODO Set a default initial credit status
-			api_error(412, 'Credit Status is required [credit_status]');
-		}
-		if (! isset($info['payment_terms'])) {
-			api_error(412, 'Payment Terms is required [payment_terms]');
-		}
-		if (! isset($info['discount'])) {
-			// TODO Set default discount as 0
-			api_error(412, 'Discount is required [discount]');
-		}
-		if (! isset($info['pymt_discount'])) {
-			// TODO Set default payment discount as 0
-			api_error(412, 'Payment Discount is required [pymt_discount]');
-		}
-		if (! isset($info['credit_limit'])) {
-			// TODO Set default credit limit from company configuration
-			api_error(412, 'Credit Limit is required [credit_limit]');
-		}
-		if (! isset($info['sales_type'])) {
-			api_error(412, 'Sales Type is required [sales_type]');
-		}
-		if (! isset($info['notes'])) {
-			$info['notes'] = '';
-		}
+        // Validate Required Fields
+        if (! isset($info['name'])) {
+            api_error(412, 'Customer Name is required [name]');
+        }
+        if (! isset($info['debtor_ref'])) {
+            api_error(412, 'Customer Reference is required [debtor_ref]');
+        }
+        if (! isset($info['address'])) {
+            api_error(412, 'Address is required [address]');
+        }
+        if (! isset($info['tax_id'])) {
+            api_error(412, 'Tax Id is required [tax_id]');
+        }
+        if (! isset($info['curr_code'])) {
+            api_error(412, 'Currency Code is required [curr_code]');
+        }
+        if (! isset($info['credit_status'])) {
+            // TODO Set a default initial credit status
+            api_error(412, 'Credit Status is required [credit_status]');
+        }
+        if (! isset($info['payment_terms'])) {
+            api_error(412, 'Payment Terms is required [payment_terms]');
+        }
+        if (! isset($info['discount'])) {
+            // TODO Set default discount as 0
+            api_error(412, 'Discount is required [discount]');
+        }
+        if (! isset($info['pymt_discount'])) {
+            // TODO Set default payment discount as 0
+            api_error(412, 'Payment Discount is required [pymt_discount]');
+        }
+        if (! isset($info['credit_limit'])) {
+            // TODO Set default credit limit from company configuration
+            api_error(412, 'Credit Limit is required [credit_limit]');
+        }
+        if (! isset($info['sales_type'])) {
+            api_error(412, 'Sales Type is required [sales_type]');
+        }
+        if (! isset($info['notes'])) {
+            $info['notes'] = '';
+        }
 
-		// For default branch
-		if (! isset($info['salesman'])) {
-			$info['salesman'] = '';
-		}
-		if (! isset($info['area'])) {
-			$info['area'] = '';
-		}
-		if (! isset($info['tax_group_id'])) {
-			$info['tax_group_id'] = '1';
-		}
-		if (! isset($info['location'])) {
-			$info['location'] = '1';
-		}
-		if (! isset($info['ship_via'])) {
-			$info['ship_via'] = '1';
-		}
-		if (! isset($info['phone'])) {
-			$info['phone'] = '';
-		}
-		if (! isset($info['phone2'])) {
-			$info['phone2'] = '';
-		}
-		if (! isset($info['fax'])) {
-			$info['fax'] = '';
-		}
-		if (! isset($info['email'])) {
-			$info['email'] = '';
-		}
+        // For default branch
+        if (! isset($info['salesman'])) {
+            $info['salesman'] = '';
+        }
+        if (! isset($info['area'])) {
+            $info['area'] = '';
+        }
+        if (! isset($info['tax_group_id'])) {
+            $info['tax_group_id'] = '1';
+        }
+        if (! isset($info['location'])) {
+            $info['location'] = '1';
+        }
+        if (! isset($info['ship_via'])) {
+            $info['ship_via'] = '1';
+        }
+        if (! isset($info['phone'])) {
+            $info['phone'] = '';
+        }
+        if (! isset($info['phone2'])) {
+            $info['phone2'] = '';
+        }
+        if (! isset($info['fax'])) {
+            $info['fax'] = '';
+        }
+        if (! isset($info['email'])) {
+            $info['email'] = '';
+        }
 
-		/*
-		 * $CustName, $debtor_ref, $address, $tax_id, $curr_code, $dimension_id, $dimension2_id, $credit_status,
-		 * $payment_terms, $discount, $pymt_discount, $credit_limit, $sales_type, $notes
-		 */
-		add_customer($info['name'], $info['debtor_ref'], $info['address'], $info['tax_id'], $info['curr_code'], 0, 0, $info['credit_status'], $info['payment_terms'], $info['discount'], $info['pymt_discount'], $info['credit_limit'], $info['sales_type'], $info['notes']);
+        /*
+         * $CustName, $debtor_ref, $address, $tax_id, $curr_code, $dimension_id, $dimension2_id, $credit_status,
+         * $payment_terms, $discount, $pymt_discount, $credit_limit, $sales_type, $notes
+         */
+        add_customer($info['name'], $info['debtor_ref'], $info['address'], $info['tax_id'], $info['curr_code'], 0, 0, $info['credit_status'], $info['payment_terms'], $info['discount'], $info['pymt_discount'], $info['credit_limit'], $info['sales_type'], $info['notes']);
 
-		$selected_id = db_insert_id();
-		$auto_create_branch = 1;
-		if (isset($auto_create_branch) && $auto_create_branch == 1) {
-			add_branch($selected_id, $info['name'], $info['debtor_ref'], $info['address'], $info['salesman'], $info['area'], $info['tax_group_id'], '1', get_company_pref('default_sales_discount_act'), get_company_pref('debtors_act'), get_company_pref('default_prompt_payment_act'), $info['location'], $info['address'], 0, 0, $info['ship_via'], $info['notes']);
+        $selected_id = db_insert_id();
+        $auto_create_branch = 1;
+        if (isset($auto_create_branch) && $auto_create_branch == 1) {
+            add_branch($selected_id, $info['name'], $info['debtor_ref'], $info['address'], $info['salesman'], $info['area'], $info['tax_group_id'], '1', get_company_pref('default_sales_discount_act'), get_company_pref('debtors_act'), get_company_pref('default_prompt_payment_act'), $info['location'], $info['address'], 0, 0, $info['ship_via'], $info['notes']);
 
-			$selected_branch = db_insert_id();
+            $selected_branch = db_insert_id();
 
-			add_crm_person($info['debtor_ref'], $info['name'], '', $info['address'], $info['phone'], $info['phone2'], $info['fax'], $info['email'], '', '');
+            add_crm_person($info['debtor_ref'], $info['name'], '', $info['address'], $info['phone'], $info['phone2'], $info['fax'], $info['email'], '', '');
 
-			$pers_id = db_insert_id();
-			add_crm_contact('cust_branch', 'general', $selected_branch, $pers_id);
+            $pers_id = db_insert_id();
+            add_crm_contact('cust_branch', 'general', $selected_branch, $pers_id);
 
-			add_crm_contact('customer', 'general', $selected_id, $pers_id);
-		}
-		$cust = get_customer($selected_id);
-		if ($cust != null) {
-			api_create_response(json_encode($cust));
-		} else {
-			api_error(500, 'Could Not Save to Database');
-		}
-	}
-	// Edit Specific Item
-	public function put($rest, $id)
-	{
-		$req = $rest->request();
-		$info = $req->post();
+            add_crm_contact('customer', 'general', $selected_id, $pers_id);
+        }
+        $cust = get_customer($selected_id);
+        if ($cust != null) {
+            api_create_response(json_encode($cust));
+        } else {
+            api_error(500, 'Could Not Save to Database');
+        }
+    }
+    // Edit Specific Item
+    public function put($rest, $id)
+    {
+        $req = $rest->request();
+        $info = $req->post();
 
-		$cust = get_customer($id);
-		if ($cust == null) {
-			api_error(400, 'Invalid Customer ID');
-		}
+        $cust = get_customer($id);
+        if ($cust == null) {
+            api_error(400, 'Invalid Customer ID');
+        }
 
-		// Validate Required Fields
-		if (! isset($info['name'])) {
-			api_error(412, 'Customer Name is required [name]');
-		}
-		if (! isset($info['debtor_ref'])) {
-			api_error(412, 'Customer Reference is required [debtor_ref]');
-		}
-		if (! isset($info['address'])) {
-			api_error(412, 'Address is required [address]');
-		}
-		if (! isset($info['tax_id'])) {
-			api_error(412, 'Tax Id is required [tax_id]');
-		}
-		if (! isset($info['curr_code'])) {
-			api_error(412, 'Currency Code is required [curr_code]');
-		}
-		if (! isset($info['credit_status'])) {
-			// TODO Set a default initial credit status
-			api_error(412, 'Credit Status is required [credit_status]');
-		}
-		if (! isset($info['payment_terms'])) {
-			api_error(412, 'Payment Terms is required [payment_terms]');
-		}
-		if (! isset($info['discount'])) {
-			// TODO Set default discount as 0
-			api_error(412, 'Discount is required [discount]');
-		}
-		if (! isset($info['pymt_discount'])) {
-			// TODO Set default payment discount as 0
-			api_error(412, 'Payment Discount is required [pymt_discount]');
-		}
-		if (! isset($info['credit_limit'])) {
-			// TODO Set default credit limit from company configuration
-			api_error(412, 'Credit Limit is required [credit_limit]');
-		}
-		if (! isset($info['sales_type'])) {
-			api_error(412, 'Sales Type is required [sales_type]');
-		}
-		if (! isset($info['notes'])) {
-			$info['notes'] = '';
-		}
+        // Validate Required Fields
+        if (! isset($info['name'])) {
+            api_error(412, 'Customer Name is required [name]');
+        }
+        if (! isset($info['debtor_ref'])) {
+            api_error(412, 'Customer Reference is required [debtor_ref]');
+        }
+        if (! isset($info['address'])) {
+            api_error(412, 'Address is required [address]');
+        }
+        if (! isset($info['tax_id'])) {
+            api_error(412, 'Tax Id is required [tax_id]');
+        }
+        if (! isset($info['curr_code'])) {
+            api_error(412, 'Currency Code is required [curr_code]');
+        }
+        if (! isset($info['credit_status'])) {
+            // TODO Set a default initial credit status
+            api_error(412, 'Credit Status is required [credit_status]');
+        }
+        if (! isset($info['payment_terms'])) {
+            api_error(412, 'Payment Terms is required [payment_terms]');
+        }
+        if (! isset($info['discount'])) {
+            // TODO Set default discount as 0
+            api_error(412, 'Discount is required [discount]');
+        }
+        if (! isset($info['pymt_discount'])) {
+            // TODO Set default payment discount as 0
+            api_error(412, 'Payment Discount is required [pymt_discount]');
+        }
+        if (! isset($info['credit_limit'])) {
+            // TODO Set default credit limit from company configuration
+            api_error(412, 'Credit Limit is required [credit_limit]');
+        }
+        if (! isset($info['sales_type'])) {
+            api_error(412, 'Sales Type is required [sales_type]');
+        }
+        if (! isset($info['notes'])) {
+            $info['notes'] = '';
+        }
 
-		/*
-		 * $customer_id, $CustName, $debtor_ref, $address, $tax_id, $curr_code, $dimension_id, $dimension2_id,
-		 * $credit_status, $payment_terms, $discount, $pymt_discount, $credit_limit, $sales_type, $notes
-		 */
-		update_customer($id, $info['name'], $info['debtor_ref'], $info['address'], $info['tax_id'], $info['curr_code'], 0, 0, $info['credit_status'], $info['payment_terms'], $info['discount'], $info['pymt_discount'], $info['credit_limit'], $info['sales_type'], $info['notes']);
+        /*
+         * $customer_id, $CustName, $debtor_ref, $address, $tax_id, $curr_code, $dimension_id, $dimension2_id,
+         * $credit_status, $payment_terms, $discount, $pymt_discount, $credit_limit, $sales_type, $notes
+         */
+        update_customer($id, $info['name'], $info['debtor_ref'], $info['address'], $info['tax_id'], $info['curr_code'], 0, 0, $info['credit_status'], $info['payment_terms'], $info['discount'], $info['pymt_discount'], $info['credit_limit'], $info['sales_type'], $info['notes']);
 
-		api_success_response("Customer has been updated");
-	}
-	// Delete Specific Item
-	public function delete($rest, $id)
-	{
-		$req = $rest->request();
-		$info = $req->post();
+        api_success_response("Customer has been updated");
+    }
+    // Delete Specific Item
+    public function delete($rest, $id)
+    {
+        $req = $rest->request();
+        $info = $req->post();
 
-		$cust = get_customer($id);
-		if ($cust == null) {
-			api_error(400, 'Invalid Customer ID');
-		}
+        $cust = get_customer($id);
+        if ($cust == null) {
+            api_error(400, 'Invalid Customer ID');
+        }
 
-		delete_customer($id);
+        delete_customer($id);
 
-		$cust = null;
-		$cust = get_customer($id);
+        $cust = null;
+        $cust = get_customer($id);
 
-		if ($cust != null) {
-			api_error(500, 'Could Not Delete from Database');
-		} else {
-			api_success_response("Customer has been deleted");
-		}
-	}
+        if ($cust != null) {
+            api_error(500, 'Could Not Delete from Database');
+        } else {
+            api_success_response("Customer has been deleted");
+        }
+    }
 
-	public function getBranches($rest, $id)
-	{
-		$sql = "SELECT " .
-			"b.branch_code, " .
-			"b.branch_ref, " .
-			"b.br_name, " .
-			"p.name as contact_name, " .
-			"s.salesman_name, " .
-			"a.description, " .
-			"p.phone, " .
-			"p.fax, " .
-			"p.email, " .
-			"t.name AS tax_group_name, " .
-			"b.inactive " .
-			" FROM " . TB_PREF . "cust_branch b " .
-			"LEFT JOIN " . TB_PREF . "crm_contacts c ON c.entity_id=b.branch_code AND c.type='cust_branch' AND c.action='general' " .
-			"LEFT JOIN " . TB_PREF . "crm_persons p on c.person_id=p.id," . TB_PREF . "areas a, " . TB_PREF . "salesman s, " . TB_PREF . "tax_groups t
+    public function getBranches($rest, $id)
+    {
+        $sql = "SELECT " .
+            "b.branch_code, " .
+            "b.branch_ref, " .
+            "b.br_name, " .
+            "p.name as contact_name, " .
+            "s.salesman_name, " .
+            "a.description, " .
+            "p.phone, " .
+            "p.fax, " .
+            "p.email, " .
+            "t.name AS tax_group_name, " .
+            "b.inactive " .
+            " FROM " . TB_PREF . "cust_branch b " .
+            "LEFT JOIN " . TB_PREF . "crm_contacts c ON c.entity_id=b.branch_code AND c.type='cust_branch' AND c.action='general' " .
+            "LEFT JOIN " . TB_PREF . "crm_persons p on c.person_id=p.id," . TB_PREF . "areas a, " . TB_PREF . "salesman s, " . TB_PREF . "tax_groups t
 			WHERE b.tax_group_id=t.id
 			AND b.area=a.area_code
 			AND b.salesman=s.salesman_code
 			AND b.debtor_no = " . db_escape($id) . " AND !b.inactive GROUP BY b.branch_code ORDER BY branch_ref";
 
-		$result = db_query($sql, "Cannot Get Customer Branches");
+        $result = db_query($sql, "Cannot Get Customer Branches");
 
-		$ret = array();
-		while ($branch = db_fetch($result)) {
+        $ret = array();
+        while ($branch = db_fetch($result)) {
+            $ret[] = array(
+                'branch_code' => $branch['branch_code'],
+                'branch_ref' => $branch['branch_ref'],
+                'br_name' => $branch['br_name'],
+                'contact_name' => $branch['contact_name'],
+                'salesman_name' => $branch['salesman_name'],
+                'description' => $branch['description'],
+                'phone' => $branch['phone'],
+                'fax' => $branch['fax'],
+                'email' => $branch['email'],
+                'tax_group_name' => $branch['tax_group_name']
+            );
+        }
+        api_success_response(json_encode($ret));
+    }
 
-			$ret[] = array(
-				'branch_code' => $branch['branch_code'],
-				'branch_ref' => $branch['branch_ref'],
-				'br_name' => $branch['br_name'],
-				'contact_name' => $branch['contact_name'],
-				'salesman_name' => $branch['salesman_name'],
-				'description' => $branch['description'],
-				'phone' => $branch['phone'],
-				'fax' => $branch['fax'],
-				'email' => $branch['email'],
-				'tax_group_name' => $branch['tax_group_name']
-			);
-		}
-		api_success_response(json_encode($ret));
-	}
+    private function customer_all($from = null)
+    {
+        if ($from == null) {
+            $from = 0;
+        }
 
-	private function customer_all($from = null)
-	{
-		if ($from == null)
-			$from = 0;
+        $sql = "SELECT * FROM " . TB_PREF . "debtors_master WHERE !inactive LIMIT " . $from . ", " . RESULTS_PER_PAGE;
 
-		$sql = "SELECT * FROM " . TB_PREF . "debtors_master WHERE !inactive LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+        $query = db_query($sql, "error");
 
-		$query = db_query($sql, "error");
+        $info = array();
 
-		$info = array();
+        while ($data = db_fetch_assoc($query, "error")) {
+            $info[] = $data;
+        }
 
-		while ($data = db_fetch_assoc($query, "error")) {
-			$info[] = $data;
-		}
-
-		api_success_response(json_encode($info));
-	}
+        api_success_response(json_encode($info));
+    }
 }

--- a/src/Dimensions.php
+++ b/src/Dimensions.php
@@ -1,0 +1,243 @@
+<?php
+namespace FAAPI;
+
+$path_to_root = "../..";
+
+include_once ($path_to_root . "/dimensions/includes/dimensions_db.inc");
+
+/**
+ * @SWG\Definition(
+ *   definition="Dimension",
+ *   type="object",
+ *   format="",
+ *   description="A Dimension",
+ *   @SWG\Property(
+ *     property="id",
+ *     type="integer",
+ *     description="Unique id used to reference a Dimension",
+ *     example="1"
+ *   ),
+ *   @SWG\Property(
+ *     property="reference",
+ *     type="string",
+ *     description="Unique short human readable reference",
+ *     example="PROJECT1"
+ *   ),
+ *   @SWG\Property(
+ *     property="name",
+ *     type="string",
+ *     description="A longer human readable name",
+ *     example="Project 1: Building buildings"
+ *   ),
+ *   @SWG\Property(
+ *     property="memo",
+ *     type="string",
+ *     description="A longer memo",
+ *     example="Some memo"
+ *   )
+ * )
+ */
+class Dimensions
+{
+    /**
+     * @SWG\Get(
+     *     path="/dimensions",
+     *     summary="List all Dimensions",
+     *     tags={"dimensions"},
+     *     operationId="listDimensions",
+     *     produces={"application/json"},
+     *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="array",
+     *             @SWG\Items(ref="#/definitions/Dimension")
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
+	public function get($rest)
+	{
+		$req = $rest->request();
+
+		$page = $req->get("page");
+
+		if ($page == null) {
+			$this->all();
+		} else {
+			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+			$from = -- $page * RESULTS_PER_PAGE;
+			$this->all($from);
+		}
+	}
+
+	/**
+     * @SWG\Get(
+     *     path="/dimensions/{id}",
+     *     summary="Get Dimension by id",
+     *     tags={"dimensions"},
+     *     operationId="getDimension",
+     *     produces={"application/json"},
+ 	 *     @SWG\Parameter(
+     *         description="ID of Dimension to return",
+     *         in="path",
+     *         name="dimensionId",
+     *         required=true,
+     *         type="integer",
+     *         format="int64"
+     *     ),
+	 *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="object",
+     *             ref="#/definitions/Dimension"
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
+	public function getById($rest, $id)
+	{
+		$result = get_dimension($id);
+		api_success_response(api_ensureAssociativeArray($result));
+	}
+
+	/**
+     * @SWG\Post(
+     *     path="/dimensions",
+     *     summary="Add Dimension",
+     *     tags={"dimensions"},
+     *     operationId="addDimension",
+     *     produces={"application/json"},
+	 *     @SWG\Parameter(
+     *         name="body",
+     *         in="body",
+     *         description="Dimension to be added",
+     *         required=true,
+     *         @SWG\Schema(ref="#/definitions/Dimension"),
+     *     ),	
+	 *     @SWG\Response(
+     *         response=201,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="object",
+	 * 			   @SWG\Property(property="id", type="string")
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
+	public function post($rest)
+	{
+		$req = $rest->request();
+		$model = $req->post();
+		\api_validate('reference', $model);
+		\api_validate('name', $model);
+		\api_check('memo', $model);
+		// add_dimension($reference, $name, $type_, $date_, $due_date, $memo_)
+		$id = add_dimension($model['reference'], $model['name'], '', '', '', $model['memo']);
+		\api_create_response(array('id' => $id));
+	}
+
+	/**
+     * @SWG\Put(
+     *     path="/dimensions/{id}",
+     *     summary="Update Dimension",
+     *     tags={"dimensions"},
+     *     operationId="updateDimension",
+     *     produces={"application/json"},
+ 	 *     @SWG\Parameter(
+     *         description="ID of Dimension to update",
+     *         in="path",
+     *         name="dimensionId",
+     *         required=true,
+     *         type="integer",
+     *         format="int64"
+     *     ),
+	 *     @SWG\Parameter(
+     *         name="body",
+     *         in="body",
+     *         description="Dimension to be updated",
+     *         required=true,
+     *         @SWG\Schema(ref="#/definitions/Dimension"),
+     *     ),	
+	 *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="object",
+	 * 			   @SWG\Property(property="id", type="string")
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
+	public function put($rest, $id)
+	{
+		$req = $rest->request();
+		$model = $req->post();
+		\api_validate('reference', $model);
+		\api_validate('name', $model);
+		\api_check('memo', $model);
+		// update_dimension($id, $name, $type_, $date_, $due_date, $memo_)
+		$id = update_dimension($id, $model['name'], '', '', '', $model['memo']);
+		\api_success_response(array('id' => $id));
+	}
+
+	/**
+     * @SWG\Delete(
+     *     path="/dimensions/{id}",
+     *     summary="Delete Dimension",
+     *     tags={"dimensions"},
+     *     operationId="deleteDimension",
+     *     produces={"application/json"},
+ 	 *     @SWG\Parameter(
+     *         description="ID of Dimension to delete",
+     *         in="path",
+     *         name="dimensionId",
+     *         required=true,
+     *         type="integer",
+     *         format="int64"
+     *     ),
+	 *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *     ),
+     *     deprecated=false
+     * )
+     */
+	public function delete($rest, $id)
+	{
+		$req = $rest->request();
+		$info = $req->post();
+		delete_dimension($id);
+		\api_success_response(array('msg' => 'deleted', 'id' => $id));
+	}
+
+	private function all($from = null)
+	{
+		$dbResult = get_dimensions();
+		$result = array(); 
+		while ($row = db_fetch_assoc($dbResult)) {
+			$result[] = $row;
+		}
+		\api_success_response($result);
+
+		// if ($from == null)
+		// 	$from = 0;
+
+		// $sql = "SELECT * FROM " . TB_PREF . "debtors_master WHERE !inactive LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+
+		// $query = db_query($sql, "error");
+
+		// $info = array();
+
+		// while ($data = db_fetch_assoc($query, "error")) {
+		// 	$info[] = $data;
+		// }
+
+		// api_success_response(json_encode($info));
+	}
+}

--- a/src/Dimensions.php
+++ b/src/Dimensions.php
@@ -3,7 +3,7 @@ namespace FAAPI;
 
 $path_to_root = "../..";
 
-include_once ($path_to_root . "/dimensions/includes/dimensions_db.inc");
+include_once($path_to_root . "/dimensions/includes/dimensions_db.inc");
 
 /**
  * @SWG\Definition(
@@ -41,203 +41,203 @@ class Dimensions
 {
     /**
      * @SWG\Get(
-     *     path="/dimensions",
-     *     summary="List all Dimensions",
-     *     tags={"dimensions"},
-     *     operationId="listDimensions",
-     *     produces={"application/json"},
-     *     @SWG\Response(
-     *         response=200,
-     *         description="successful operation",
-     *         @SWG\Schema(
-     *             type="array",
-     *             @SWG\Items(ref="#/definitions/Dimension")
-     *         )
-     *     ),
-     *     deprecated=false
+     *   path="/dimensions",
+     *   summary="List all Dimensions",
+     *   tags={"dimensions"},
+     *   operationId="listDimensions",
+     *   produces={"application/json"},
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="array",
+     *       @SWG\Items(ref="#/definitions/Dimension")
+     *     )
+     *   ),
+     *   deprecated=false
      * )
      */
-	public function get($rest)
-	{
-		$req = $rest->request();
+    public function get($rest)
+    {
+        $req = $rest->request();
 
-		$page = $req->get("page");
+        $page = $req->get("page");
 
-		if ($page == null) {
-			$this->all();
-		} else {
-			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
-			$from = -- $page * RESULTS_PER_PAGE;
-			$this->all($from);
-		}
-	}
+        if ($page == null) {
+            $this->all();
+        } else {
+            // If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+            $from = -- $page * RESULTS_PER_PAGE;
+            $this->all($from);
+        }
+    }
 
-	/**
+    /**
      * @SWG\Get(
-     *     path="/dimensions/{id}",
-     *     summary="Get Dimension by id",
-     *     tags={"dimensions"},
-     *     operationId="getDimension",
-     *     produces={"application/json"},
- 	 *     @SWG\Parameter(
-     *         description="ID of Dimension to return",
-     *         in="path",
-     *         name="dimensionId",
-     *         required=true,
-     *         type="integer",
-     *         format="int64"
-     *     ),
-	 *     @SWG\Response(
-     *         response=200,
-     *         description="successful operation",
-     *         @SWG\Schema(
-     *             type="object",
-     *             ref="#/definitions/Dimension"
-     *         )
-     *     ),
-     *     deprecated=false
+     *   path="/dimensions/{id}",
+     *   summary="Get Dimension by id",
+     *   tags={"dimensions"},
+     *   operationId="getDimension",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     description="ID of Dimension to return",
+     *     in="path",
+     *     name="dimensionId",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="object",
+     *       ref="#/definitions/Dimension"
+     *     )
+     *   ),
+     *   deprecated=false
      * )
      */
-	public function getById($rest, $id)
-	{
-		$result = get_dimension($id);
-		api_success_response(api_ensureAssociativeArray($result));
-	}
+    public function getById($rest, $id)
+    {
+        $result = get_dimension($id);
+        api_success_response(api_ensureAssociativeArray($result));
+    }
 
-	/**
+    /**
      * @SWG\Post(
-     *     path="/dimensions",
-     *     summary="Add Dimension",
-     *     tags={"dimensions"},
-     *     operationId="addDimension",
-     *     produces={"application/json"},
-	 *     @SWG\Parameter(
-     *         name="body",
-     *         in="body",
-     *         description="Dimension to be added",
-     *         required=true,
-     *         @SWG\Schema(ref="#/definitions/Dimension"),
-     *     ),	
-	 *     @SWG\Response(
-     *         response=201,
-     *         description="successful operation",
-     *         @SWG\Schema(
-     *             type="object",
-	 * 			   @SWG\Property(property="id", type="string")
-     *         )
-     *     ),
-     *     deprecated=false
+     *   path="/dimensions",
+     *   summary="Add Dimension",
+     *   tags={"dimensions"},
+     *   operationId="addDimension",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="body",
+     *     in="body",
+     *     description="Dimension to be added",
+     *     required=true,
+     *     @SWG\Schema(ref="#/definitions/Dimension"),
+     *   ),
+     *   @SWG\Response(
+     *     response=201,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="object",
+     * 	     @SWG\Property(property="id", type="string")
+     *     )
+     *   ),
+     *   deprecated=false
      * )
      */
-	public function post($rest)
-	{
-		$req = $rest->request();
-		$model = $req->post();
-		\api_validate('reference', $model);
-		\api_validate('name', $model);
-		\api_check('memo', $model);
-		// add_dimension($reference, $name, $type_, $date_, $due_date, $memo_)
-		$id = add_dimension($model['reference'], $model['name'], '', '', '', $model['memo']);
-		\api_create_response(array('id' => $id));
-	}
+    public function post($rest)
+    {
+        $req = $rest->request();
+        $model = $req->post();
+        \api_validate('reference', $model);
+        \api_validate('name', $model);
+        \api_check('memo', $model);
+        // add_dimension($reference, $name, $type_, $date_, $due_date, $memo_)
+        $id = add_dimension($model['reference'], $model['name'], '', '', '', $model['memo']);
+        \api_create_response(array('id' => $id));
+    }
 
-	/**
+    /**
      * @SWG\Put(
-     *     path="/dimensions/{id}",
-     *     summary="Update Dimension",
-     *     tags={"dimensions"},
-     *     operationId="updateDimension",
-     *     produces={"application/json"},
- 	 *     @SWG\Parameter(
-     *         description="ID of Dimension to update",
-     *         in="path",
-     *         name="dimensionId",
-     *         required=true,
-     *         type="integer",
-     *         format="int64"
-     *     ),
-	 *     @SWG\Parameter(
-     *         name="body",
-     *         in="body",
-     *         description="Dimension to be updated",
-     *         required=true,
-     *         @SWG\Schema(ref="#/definitions/Dimension"),
-     *     ),	
-	 *     @SWG\Response(
-     *         response=200,
-     *         description="successful operation",
-     *         @SWG\Schema(
-     *             type="object",
-	 * 			   @SWG\Property(property="id", type="string")
-     *         )
-     *     ),
-     *     deprecated=false
+     *   path="/dimensions/{id}",
+     *   summary="Update Dimension",
+     *   tags={"dimensions"},
+     *   operationId="updateDimension",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     description="ID of Dimension to update",
+     *     in="path",
+     *     name="dimensionId",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Parameter(
+     *     name="body",
+     *     in="body",
+     *     description="Dimension to be updated",
+     *     required=true,
+     *     @SWG\Schema(ref="#/definitions/Dimension"),
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="object",
+     *       @SWG\Property(property="id", type="string")
+     *     )
+     *   ),
+     *   deprecated=false
      * )
      */
-	public function put($rest, $id)
-	{
-		$req = $rest->request();
-		$model = $req->post();
-		\api_validate('reference', $model);
-		\api_validate('name', $model);
-		\api_check('memo', $model);
-		// update_dimension($id, $name, $type_, $date_, $due_date, $memo_)
-		$id = update_dimension($id, $model['name'], '', '', '', $model['memo']);
-		\api_success_response(array('id' => $id));
-	}
+    public function put($rest, $id)
+    {
+        $req = $rest->request();
+        $model = $req->post();
+        \api_validate('reference', $model);
+        \api_validate('name', $model);
+        \api_check('memo', $model);
+        // update_dimension($id, $name, $type_, $date_, $due_date, $memo_)
+        $id = update_dimension($id, $model['name'], '', '', '', $model['memo']);
+        \api_success_response(array('id' => $id));
+    }
 
-	/**
+    /**
      * @SWG\Delete(
-     *     path="/dimensions/{id}",
-     *     summary="Delete Dimension",
-     *     tags={"dimensions"},
-     *     operationId="deleteDimension",
-     *     produces={"application/json"},
- 	 *     @SWG\Parameter(
-     *         description="ID of Dimension to delete",
-     *         in="path",
-     *         name="dimensionId",
-     *         required=true,
-     *         type="integer",
-     *         format="int64"
-     *     ),
-	 *     @SWG\Response(
-     *         response=200,
-     *         description="successful operation",
-     *     ),
-     *     deprecated=false
+     *   path="/dimensions/{id}",
+     *   summary="Delete Dimension",
+     *   tags={"dimensions"},
+     *   operationId="deleteDimension",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     description="ID of Dimension to delete",
+     *     in="path",
+     *     name="dimensionId",
+     *     required=true,
+     *     type="integer",
+     *     format="int64"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *   ),
+     *   deprecated=false
      * )
      */
-	public function delete($rest, $id)
-	{
-		$req = $rest->request();
-		$info = $req->post();
-		delete_dimension($id);
-		\api_success_response(array('msg' => 'deleted', 'id' => $id));
-	}
+    public function delete($rest, $id)
+    {
+        $req = $rest->request();
+        $info = $req->post();
+        delete_dimension($id);
+        \api_success_response(array('msg' => 'deleted', 'id' => $id));
+    }
 
-	private function all($from = null)
-	{
-		$dbResult = get_dimensions();
-		$result = array(); 
-		while ($row = db_fetch_assoc($dbResult)) {
-			$result[] = $row;
-		}
-		\api_success_response($result);
+    private function all($from = null)
+    {
+        $dbResult = get_dimensions();
+        $result = array();
+        while ($row = db_fetch_assoc($dbResult)) {
+            $result[] = $row;
+        }
+        \api_success_response($result);
 
-		// if ($from == null)
-		// 	$from = 0;
+        // if ($from == null)
+        // 	$from = 0;
 
-		// $sql = "SELECT * FROM " . TB_PREF . "debtors_master WHERE !inactive LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+        // $sql = "SELECT * FROM " . TB_PREF . "debtors_master WHERE !inactive LIMIT " . $from . ", " . RESULTS_PER_PAGE;
 
-		// $query = db_query($sql, "error");
+        // $query = db_query($sql, "error");
 
-		// $info = array();
+        // $info = array();
 
-		// while ($data = db_fetch_assoc($query, "error")) {
-		// 	$info[] = $data;
-		// }
+        // while ($data = db_fetch_assoc($query, "error")) {
+        // 	$info[] = $data;
+        // }
 
-		// api_success_response(json_encode($info));
-	}
+        // api_success_response(json_encode($info));
+    }
 }

--- a/src/GLAccounts.php
+++ b/src/GLAccounts.php
@@ -6,9 +6,64 @@ $path_to_root = "../..";
 include_once ($path_to_root . "/gl/includes/db/gl_db_accounts.inc");
 include_once ($path_to_root . "/gl/includes/db/gl_db_account_types.inc");
 
+/**
+ * @SWG\Definition(
+ *   definition="GLAccount",
+ *   type="object",
+ *   format="",
+ *   description="A GLAccount",
+ *   @SWG\Property(
+ *     property="account_code",
+ *     type="string",
+ *     description="Unique short human readable id used to reference a GLAccount",
+ *     example="1060"
+ *   ),
+ *   @SWG\Property(
+ *     property="account_code2",
+ *     type="string",
+ *     description="Secondary account code, may be blank",
+ *     example=""
+ *   ),
+ *   @SWG\Property(
+ *     property="account_name",
+ *     type="string",
+ *     description="A longer name for the account",
+ *     example="My Bank Savings Account"
+ *   ),
+ *   @SWG\Property(
+ *     property="account_type",
+ *     type="string",
+ *     description="Type of the account",
+ *     example=""
+ *   ),
+ *   @SWG\Property(
+ *     property="inactive",
+ *     type="int",
+ *     description="Zero if account is active",
+ *     example="0"
+ *   )
+ * )
+ */
 class GLAccounts
 {
-	// Get Items
+    /**
+     * @SWG\Get(
+     *     path="/glaccounts",
+     *     summary="List all GL Accounts",
+     *     tags={"glaccounts"},
+     *     operationId="listGLAccounts",
+     *     produces={"application/json"},
+     *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="array",
+     *             @SWG\Items(ref="#/definitions/GLAccount")
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
 	public function get($rest)
 	{
 		$req = $rest->request();
@@ -24,12 +79,159 @@ class GLAccounts
 		}
 	}
 
-	// Get Specific Item by Stock Id
+	/**
+     * @SWG\Get(
+     *     path="/glaccounts/{id}",
+     *     summary="Get GL Account by id",
+     *     tags={"glaccounts"},
+     *     operationId="getGLAccount",
+     *     produces={"application/json"},
+ 	 *     @SWG\Parameter(
+     *         description="ID of GL Account to return",
+     *         in="path",
+     *         name="glAccountId",
+     *         required=true,
+     *         type="string"
+     *     ),
+	 *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="object",
+     *             ref="#/definitions/GLAccount"
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
 	public function getById($rest, $id)
 	{
-		$acct = get_gl_account($id);
-		api_success_response(json_encode(\api_ensureAssociativeArray($acct)));
+		$result = get_gl_account($id);
+		api_success_response(\api_ensureAssociativeArray($result));
 	}
+
+	/**
+     * @SWG\Post(
+     *     path="/glaccounts",
+     *     summary="Add GL Account",
+     *     tags={"glaccounts"},
+     *     operationId="addGLAccount",
+     *     produces={"application/json"},
+	 *     @SWG\Parameter(
+     *         name="body",
+     *         in="body",
+     *         description="GL Account to be added",
+     *         required=true,
+     *         @SWG\Schema(ref="#/definitions/GLAccount"),
+     *     ),	
+	 *     @SWG\Response(
+     *         response=201,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="object",
+	 * 			   @SWG\Property(property="account_code", type="string")
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
+	public function post($rest)
+	{
+		$req = $rest->request();
+		$model = $req->post();
+		\api_validate('account_code', $model);
+		\api_validate('account_name', $model);
+		\api_validate('account_type', $model);
+		\api_check('account_code2', $model);
+		\api_check('inactive', $model, '0');
+
+		// add_gl_account($account_code, $account_name, $account_type, $account_code2)
+		add_gl_account($model['account_code'], $model['account_name'], $model['account_type'], $model['account_code2']);
+		// TODO Read back to check before returning success
+
+		\api_create_response(array('account_code' => $model['account_code']));
+	}
+
+	/**
+     * @SWG\Put(
+     *     path="/glaccounts/{id}",
+     *     summary="Update GL Account",
+     *     tags={"glaccounts"},
+     *     operationId="updateGLAccount",
+     *     produces={"application/json"},
+ 	 *     @SWG\Parameter(
+     *         description="ID of GL Account to update",
+     *         in="path",
+     *         name="dimensionId",
+     *         required=true,
+     *         type="string"
+     *     ),
+	 *     @SWG\Parameter(
+     *         name="body",
+     *         in="body",
+     *         description="GL Account to be updated",
+     *         required=true,
+     *         @SWG\Schema(ref="#/definitions/GLAccount"),
+     *     ),	
+	 *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="object",
+	 * 			   @SWG\Property(property="account_code", type="string")
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
+	public function put($rest, $id)
+	{
+		$req = $rest->request();
+		$model = $req->post();
+		\api_validate('account_code', $model);
+		\api_validate('account_name', $model);
+		\api_validate('account_type', $model);
+		\api_check('account_code2', $model);
+		\api_check('inactive', $model, '0');
+
+		// update_gl_account($account_code, $account_name, $account_type, $account_code2)
+		update_gl_account($model['account_code'], $model['account_name'], $model['account_type'], $model['account_code2']);
+		// TODO Read back to check before returning success
+
+		\api_success_response(array('account_code' => $id));
+	}
+
+	/**
+     * @SWG\Delete(
+     *     path="/glaccounts/{id}",
+     *     summary="Delete GL Account",
+     *     tags={"glaccounts"},
+     *     operationId="deleteGLAccount",
+     *     produces={"application/json"},
+ 	 *     @SWG\Parameter(
+     *         description="ID of GL Account to delete",
+     *         in="path",
+     *         name="glAccountId",
+     *         required=true,
+     *         type="string"
+     *     ),
+	 *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *     ),
+     *     deprecated=false
+     * )
+     */
+	public function delete($rest, $id)
+	{
+		$req = $rest->request();
+		$info = $req->post();
+
+		delete_gl_account($id);
+
+		\api_success_response(array('msg' => 'deleted', 'id' => $id));
+	}
+
 
 	public function getTypes($rest)
 	{
@@ -51,7 +253,10 @@ class GLAccounts
 		if ($from == null)
 			$from = 0;
 
-		$sql = "SELECT " . TB_PREF . "chart_master.*," . TB_PREF . "chart_types.name AS AccountTypeName FROM " . TB_PREF . "chart_master," . TB_PREF . "chart_types WHERE " . TB_PREF . "chart_master.account_type=" . TB_PREF . "chart_types.id ORDER BY account_code LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+		// TODO Paging doesn't work CP 2018-06
+		// $sql = "SELECT " . TB_PREF . "chart_master.*," . TB_PREF . "chart_types.name AS AccountTypeName FROM " . TB_PREF . "chart_master," . TB_PREF . "chart_types WHERE " . TB_PREF . "chart_master.account_type=" . TB_PREF . "chart_types.id ORDER BY account_code LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+
+		$sql = "SELECT " . TB_PREF . "chart_master.*," . TB_PREF . "chart_types.name AS AccountTypeName FROM " . TB_PREF . "chart_master," . TB_PREF . "chart_types WHERE " . TB_PREF . "chart_master.account_type=" . TB_PREF . "chart_types.id ORDER BY account_code";
 
 		$query = db_query($sql, "error");
 

--- a/src/GLAccounts.php
+++ b/src/GLAccounts.php
@@ -3,8 +3,8 @@ namespace FAAPI;
 
 $path_to_root = "../..";
 
-include_once ($path_to_root . "/gl/includes/db/gl_db_accounts.inc");
-include_once ($path_to_root . "/gl/includes/db/gl_db_account_types.inc");
+include_once($path_to_root . "/gl/includes/db/gl_db_accounts.inc");
+include_once($path_to_root . "/gl/includes/db/gl_db_account_types.inc");
 
 /**
  * @SWG\Definition(
@@ -48,229 +48,226 @@ class GLAccounts
 {
     /**
      * @SWG\Get(
-     *     path="/glaccounts",
-     *     summary="List all GL Accounts",
-     *     tags={"glaccounts"},
-     *     operationId="listGLAccounts",
-     *     produces={"application/json"},
-     *     @SWG\Response(
-     *         response=200,
-     *         description="successful operation",
-     *         @SWG\Schema(
-     *             type="array",
-     *             @SWG\Items(ref="#/definitions/GLAccount")
-     *         )
-     *     ),
-     *     deprecated=false
+     *   path="/glaccounts",
+     *   summary="List all GL Accounts",
+     *   tags={"glaccounts"},
+     *   operationId="listGLAccounts",
+     *   produces={"application/json"},
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="array",
+     *       @SWG\Items(ref="#/definitions/GLAccount")
+     *     )
+     *   ),
+     *   deprecated=false
      * )
      */
-	public function get($rest)
-	{
-		$req = $rest->request();
+    public function get($rest)
+    {
+        $req = $rest->request();
 
-		$page = $req->get("page");
+        $page = $req->get("page");
 
-		if ($page == null) {
-			$this->glaccounts_all();
-		} else {
-			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
-			$from = -- $page * RESULTS_PER_PAGE;
-			$this->glaccounts_all($from);
-		}
-	}
+        if ($page == null) {
+            $this->glaccounts_all();
+        } else {
+            // If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+            $from = -- $page * RESULTS_PER_PAGE;
+            $this->glaccounts_all($from);
+        }
+    }
 
-	/**
+    /**
      * @SWG\Get(
-     *     path="/glaccounts/{id}",
-     *     summary="Get GL Account by id",
-     *     tags={"glaccounts"},
-     *     operationId="getGLAccount",
-     *     produces={"application/json"},
- 	 *     @SWG\Parameter(
-     *         description="ID of GL Account to return",
-     *         in="path",
-     *         name="glAccountId",
-     *         required=true,
-     *         type="string"
-     *     ),
-	 *     @SWG\Response(
-     *         response=200,
-     *         description="successful operation",
-     *         @SWG\Schema(
-     *             type="object",
-     *             ref="#/definitions/GLAccount"
-     *         )
-     *     ),
-     *     deprecated=false
+     *   path="/glaccounts/{id}",  
+     *   summary="Get GL Account by id",
+     *   tags={"glaccounts"},
+     *   operationId="getGLAccount",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     description="ID of GL Account to return",
+     *     in="path",
+     *     name="glAccountId",
+     *     required=true,
+     *     type="string"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="object",
+     *       ref="#/definitions/GLAccount"
+     *     )
+     *   ),
+     *   deprecated=false
      * )
      */
-	public function getById($rest, $id)
-	{
-		$result = get_gl_account($id);
-		api_success_response(\api_ensureAssociativeArray($result));
-	}
+    public function getById($rest, $id)
+    {
+        $result = get_gl_account($id);
+        api_success_response(\api_ensureAssociativeArray($result));
+    }
 
-	/**
+    /**
      * @SWG\Post(
-     *     path="/glaccounts",
-     *     summary="Add GL Account",
-     *     tags={"glaccounts"},
-     *     operationId="addGLAccount",
-     *     produces={"application/json"},
-	 *     @SWG\Parameter(
-     *         name="body",
-     *         in="body",
-     *         description="GL Account to be added",
-     *         required=true,
-     *         @SWG\Schema(ref="#/definitions/GLAccount"),
-     *     ),	
-	 *     @SWG\Response(
-     *         response=201,
-     *         description="successful operation",
-     *         @SWG\Schema(
-     *             type="object",
-	 * 			   @SWG\Property(property="account_code", type="string")
-     *         )
-     *     ),
-     *     deprecated=false
+     *   path="/glaccounts",
+     *   summary="Add GL Account",
+     *   tags={"glaccounts"},
+     *   operationId="addGLAccount",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     name="body",
+     *     in="body",
+     *     description="GL Account to be added",
+     *     required=true,
+     *     @SWG\Schema(ref="#/definitions/GLAccount"),
+     *   ),
+     *   @SWG\Response(
+     *     response=201,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="object",
+     *       @SWG\Property(property="account_code", type="string")
+     *     )
+     *   ),
+     *   deprecated=false
      * )
      */
-	public function post($rest)
-	{
-		$req = $rest->request();
-		$model = $req->post();
-		\api_validate('account_code', $model);
-		\api_validate('account_name', $model);
-		\api_validate('account_type', $model);
-		\api_check('account_code2', $model);
-		\api_check('inactive', $model, '0');
+    public function post($rest)
+    {
+        $req = $rest->request();
+        $model = $req->post();
+        \api_validate('account_code', $model);
+        \api_validate('account_name', $model);
+        \api_validate('account_type', $model);
+        \api_check('account_code2', $model);
+        \api_check('inactive', $model, '0');
 
-		// add_gl_account($account_code, $account_name, $account_type, $account_code2)
-		add_gl_account($model['account_code'], $model['account_name'], $model['account_type'], $model['account_code2']);
-		// TODO Read back to check before returning success
+        // add_gl_account($account_code, $account_name, $account_type, $account_code2)
+        add_gl_account($model['account_code'], $model['account_name'], $model['account_type'], $model['account_code2']);
+        // TODO Read back to check before returning success
 
-		\api_create_response(array('account_code' => $model['account_code']));
-	}
+        \api_create_response(array('account_code' => $model['account_code']));
+    }
 
-	/**
+    /**
      * @SWG\Put(
-     *     path="/glaccounts/{id}",
-     *     summary="Update GL Account",
-     *     tags={"glaccounts"},
-     *     operationId="updateGLAccount",
-     *     produces={"application/json"},
- 	 *     @SWG\Parameter(
-     *         description="ID of GL Account to update",
-     *         in="path",
-     *         name="dimensionId",
-     *         required=true,
-     *         type="string"
-     *     ),
-	 *     @SWG\Parameter(
-     *         name="body",
-     *         in="body",
-     *         description="GL Account to be updated",
-     *         required=true,
-     *         @SWG\Schema(ref="#/definitions/GLAccount"),
-     *     ),	
-	 *     @SWG\Response(
-     *         response=200,
-     *         description="successful operation",
-     *         @SWG\Schema(
-     *             type="object",
-	 * 			   @SWG\Property(property="account_code", type="string")
-     *         )
-     *     ),
-     *     deprecated=false
+     *   path="/glaccounts/{id}",
+     *   summary="Update GL Account",
+     *   tags={"glaccounts"},
+     *   operationId="updateGLAccount",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     description="ID of GL Account to update",
+     *     in="path",
+     *     name="glAccountId",
+     *     required=true,
+     *     type="string"
+     *   ),
+     *   @SWG\Parameter(
+     *     name="body",
+     *     in="body",
+     *     description="GL Account to be updated",
+     *     required=true,
+     *     @SWG\Schema(ref="#/definitions/GLAccount"),
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *     @SWG\Schema(
+     *       type="object",
+     * 	     @SWG\Property(property="account_code", type="string")
+     *     )
+     *   ),
+     *   deprecated=false
      * )
      */
-	public function put($rest, $id)
-	{
-		$req = $rest->request();
-		$model = $req->post();
-		\api_validate('account_code', $model);
-		\api_validate('account_name', $model);
-		\api_validate('account_type', $model);
-		\api_check('account_code2', $model);
-		\api_check('inactive', $model, '0');
+    public function put($rest, $id)
+    {
+        $req = $rest->request();
+        $model = $req->post();
+        \api_validate('account_code', $model);
+        \api_validate('account_name', $model);
+        \api_validate('account_type', $model);
+        \api_check('account_code2', $model);
+        \api_check('inactive', $model, '0');
 
-		// update_gl_account($account_code, $account_name, $account_type, $account_code2)
-		update_gl_account($model['account_code'], $model['account_name'], $model['account_type'], $model['account_code2']);
-		// TODO Read back to check before returning success
+        // update_gl_account($account_code, $account_name, $account_type, $account_code2)
+        update_gl_account($model['account_code'], $model['account_name'], $model['account_type'], $model['account_code2']);
+        // TODO Read back to check before returning success
 
-		\api_success_response(array('account_code' => $id));
-	}
+        \api_success_response(array('account_code' => $id));
+    }
 
-	/**
+    /**
      * @SWG\Delete(
-     *     path="/glaccounts/{id}",
-     *     summary="Delete GL Account",
-     *     tags={"glaccounts"},
-     *     operationId="deleteGLAccount",
-     *     produces={"application/json"},
- 	 *     @SWG\Parameter(
-     *         description="ID of GL Account to delete",
-     *         in="path",
-     *         name="glAccountId",
-     *         required=true,
-     *         type="string"
-     *     ),
-	 *     @SWG\Response(
-     *         response=200,
-     *         description="successful operation",
-     *     ),
-     *     deprecated=false
+     *   path="/glaccounts/{id}",
+     *   summary="Delete GL Account",
+     *   tags={"glaccounts"},
+     *   operationId="deleteGLAccount",
+     *   produces={"application/json"},
+     *   @SWG\Parameter(
+     *     description="ID of GL Account to delete",
+     *     in="path",
+     *     name="glAccountId",
+     *     required=true,
+     *     type="string"
+     *   ),
+     *   @SWG\Response(
+     *     response=200,
+     *     description="successful operation",
+     *   ),
+     *   deprecated=false
      * )
      */
-	public function delete($rest, $id)
-	{
-		$req = $rest->request();
-		$info = $req->post();
+    public function delete($rest, $id)
+    {
+        $req = $rest->request();
+        $info = $req->post();
 
-		delete_gl_account($id);
+        delete_gl_account($id);
 
-		\api_success_response(array('msg' => 'deleted', 'id' => $id));
-	}
+        \api_success_response(array('msg' => 'deleted', 'id' => $id));
+    }
 
+    // TODO Docs CP 2018-06
+    public function getTypes($rest)
+    {
+        $accttypes = get_account_types();
+        $ret = array();
+        while ($type = db_fetch($accttypes)) {
+            $ret[] = array(
+                'id' => $type['id'],
+                'name' => $type['name'],
+                'class_id' => $type['class_id'],
+                'parent' => $type['parent']
+            );
+        }
+        api_success_response(json_encode($ret));
+    }
 
-	public function getTypes($rest)
-	{
-		$accttypes = get_account_types();
-		$ret = array();
-		while ($type = db_fetch($accttypes)) {
-			$ret[] = array(
-				'id' => $type['id'],
-				'name' => $type['name'],
-				'class_id' => $type['class_id'],
-				'parent' => $type['parent']
-			);
-		}
-		api_success_response(json_encode($ret));
-	}
+    private function glaccounts_all($from = null)
+    {
+        if ($from == null) {
+            $from = 0;
+        }
 
-	private function glaccounts_all($from = null)
-	{
-		if ($from == null)
-			$from = 0;
+        // TODO Paging doesn't work CP 2018-06
+        // $sql = "SELECT " . TB_PREF . "chart_master.*," . TB_PREF . "chart_types.name AS AccountTypeName FROM " . TB_PREF . "chart_master," . TB_PREF . "chart_types WHERE " . TB_PREF . "chart_master.account_type=" . TB_PREF . "chart_types.id ORDER BY account_code LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+        $sql = "SELECT " . TB_PREF . "chart_master.*," . TB_PREF . "chart_types.name AS AccountTypeName FROM " . TB_PREF . "chart_master," . TB_PREF . "chart_types WHERE " . TB_PREF . "chart_master.account_type=" . TB_PREF . "chart_types.id ORDER BY account_code";
+        $query = db_query($sql, "error");
+        $info = array();
+        while ($data = db_fetch($query, "error")) {
+            $info[] = array(
+                'account_code' => $data['account_code'],
+                'account_name' => $data['account_name'],
+                'account_type' => $data['account_type'],
+                'account_code2' => $data['account_code2']
+            );
+        }
 
-		// TODO Paging doesn't work CP 2018-06
-		// $sql = "SELECT " . TB_PREF . "chart_master.*," . TB_PREF . "chart_types.name AS AccountTypeName FROM " . TB_PREF . "chart_master," . TB_PREF . "chart_types WHERE " . TB_PREF . "chart_master.account_type=" . TB_PREF . "chart_types.id ORDER BY account_code LIMIT " . $from . ", " . RESULTS_PER_PAGE;
-
-		$sql = "SELECT " . TB_PREF . "chart_master.*," . TB_PREF . "chart_types.name AS AccountTypeName FROM " . TB_PREF . "chart_master," . TB_PREF . "chart_types WHERE " . TB_PREF . "chart_master.account_type=" . TB_PREF . "chart_types.id ORDER BY account_code";
-
-		$query = db_query($sql, "error");
-
-		$info = array();
-
-		while ($data = db_fetch($query, "error")) {
-			$info[] = array(
-				'account_code' => $data['account_code'],
-				'account_name' => $data['account_name'],
-				'account_type' => $data['account_type'],
-				'account_code2' => $data['account_code2']
-			);
-		}
-
-		api_success_response(json_encode($info));
-	}
+        api_success_response(json_encode($info));
+    }
 }

--- a/src/Inventory.php
+++ b/src/Inventory.php
@@ -3,267 +3,266 @@ namespace FAAPI;
 
 $path_to_root = "../..";
 
-include_once ($path_to_root . "/inventory/includes/inventory_db.inc");
-include_once ($path_to_root . "/inventory/includes/db/items_codes_db.inc");
-include_once ($path_to_root . "/inventory/includes/db/items_locations_db.inc");
-include_once ($path_to_root . "/gl/includes/gl_db.inc");
-include_once ($path_to_root . "/includes/ui/items_cart.inc");
+include_once($path_to_root . "/inventory/includes/inventory_db.inc");
+include_once($path_to_root . "/inventory/includes/db/items_codes_db.inc");
+include_once($path_to_root . "/inventory/includes/db/items_locations_db.inc");
+include_once($path_to_root . "/gl/includes/gl_db.inc");
+include_once($path_to_root . "/includes/ui/items_cart.inc");
 
-include_once (API_ROOT . "/inventory.inc");
+include_once(API_ROOT . "/inventory.inc");
 
 class Inventory
 {
-	// Get Items
-	public function get($rest)
-	{
-		$req = $rest->request();
+    // Get Items
+    public function get($rest)
+    {
+        $req = $rest->request();
 
-		$page = $req->get("page");
+        $page = $req->get("page");
 
-		if ($page == null) {
-			$this->inventory_all();
-		} else {
-			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
-			$from = -- $page * RESULTS_PER_PAGE;
-			$this->inventory_all($from);
-		}
-	}
+        if ($page == null) {
+            $this->inventory_all();
+        } else {
+            // If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+            $from = -- $page * RESULTS_PER_PAGE;
+            $this->inventory_all($from);
+        }
+    }
 
-	// Get Specific Item by Stock Id
-	public function getById($rest, $id)
-	{
-		$this->inventory_get($id);
-	}
-	// Add Item
-	public function post($rest)
-	{
-		$this->inventory_add();
-	}
-	// Edit Specific Item
-	public function put($rest, $id)
-	{
-		$this->inventory_edit($id);
-	}
-	// Delete Specific Item
-	public function delete($rest, $id)
-	{
-		$this->inventory_delete($id);
-	}
+    // Get Specific Item by Stock Id
+    public function getById($rest, $id)
+    {
+        $this->inventory_get($id);
+    }
+    // Add Item
+    public function post($rest)
+    {
+        $this->inventory_add();
+    }
+    // Edit Specific Item
+    public function put($rest, $id)
+    {
+        $this->inventory_edit($id);
+    }
+    // Delete Specific Item
+    public function delete($rest, $id)
+    {
+        $this->inventory_delete($id);
+    }
 
-	function inventory_all($from = null)
-	{
-		if ($from == null)
-			$from = 0;
+    public function inventory_all($from = null)
+    {
+        if ($from == null) {
+            $from = 0;
+        }
 
-		$sql = "SELECT * FROM " . TB_PREF . "stock_master LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+        $sql = "SELECT * FROM " . TB_PREF . "stock_master LIMIT " . $from . ", " . RESULTS_PER_PAGE;
 
-		$query = db_query($sql, "error");
+        $query = db_query($sql, "error");
 
-		$info = array();
+        $info = array();
 
-		while ($data = db_fetch($query, "error")) {
-			$info[] = array(
-				'stock_id' => $data['stock_id'],
-				'category_id' => $data['category_id'],
-				'tax_type_id' => $data['tax_type_id'],
-				'description' => $data['description'],
-				'long_description' => $data['long_description'],
-				'units' => $data['units'],
-				'mb_flag' => $data['mb_flag'],
-				'sales_account' => $data['sales_account'],
-				'cogs_account' => $data['cogs_account'],
-				'inventory_account' => $data['inventory_account'],
-				'adjustment_account' => $data['adjustment_account'],
-				'wip_account' => $data['wip_account'],
-				'purchase_cost' => $data['purchase_cost'],
-				'last_cost' => $data['last_cost'],
-				'material_cost' => $data['material_cost'],
-				'labour_cost' => $data['labour_cost'],
-				'overhead_cost' => $data['overhead_cost'],
-				'inactive' => $data['inactive'],
-				'no_sale' => $data['no_sale'],
-				'no_purchase' => $data['no_purchase']
-			);
-		}
+        while ($data = db_fetch($query, "error")) {
+            $info[] = array(
+                'stock_id' => $data['stock_id'],
+                'category_id' => $data['category_id'],
+                'tax_type_id' => $data['tax_type_id'],
+                'description' => $data['description'],
+                'long_description' => $data['long_description'],
+                'units' => $data['units'],
+                'mb_flag' => $data['mb_flag'],
+                'sales_account' => $data['sales_account'],
+                'cogs_account' => $data['cogs_account'],
+                'inventory_account' => $data['inventory_account'],
+                'adjustment_account' => $data['adjustment_account'],
+                'wip_account' => $data['wip_account'],
+                'purchase_cost' => $data['purchase_cost'],
+                'last_cost' => $data['last_cost'],
+                'material_cost' => $data['material_cost'],
+                'labour_cost' => $data['labour_cost'],
+                'overhead_cost' => $data['overhead_cost'],
+                'inactive' => $data['inactive'],
+                'no_sale' => $data['no_sale'],
+                'no_purchase' => $data['no_purchase']
+            );
+        }
 
-		api_success_response(json_encode($info));
-	}
+        api_success_response(json_encode($info));
+    }
 
-	function inventory_get($id)
-	{
-		$item = get_item($id);
-		api_success_response(json_encode(api_ensureAssociativeArray($item)));
-	}
+    public function inventory_get($id)
+    {
+        $item = get_item($id);
+        api_success_response(json_encode(api_ensureAssociativeArray($item)));
+    }
 
-	function inventory_add()
-	{
-		$app = \Slim\Slim::getInstance('SASYS');
-		$req = $app->request();
-		$info = $req->post();
+    public function inventory_add()
+    {
+        $app = \Slim\Slim::getInstance('SASYS');
+        $req = $app->request();
+        $info = $req->post();
 
-		// Validate Required Fields
-		if (! isset($info['stock_id'])) {
-			api_error(412, 'Stock Id is required');
-		}
-		if (! isset($info['description'])) {
-			api_error(412, 'Description is required');
-		}
-		if (! isset($info['long_description'])) {
-			$info['long_description'] = $info['description'];
-		}
-		if (! isset($info['category_id'])) {
-			api_error(412, 'Category Id is required');
-		}
-		if (! isset($info['tax_type_id'])) {
-			api_error(412, 'Tax Type is required');
-		}
-		if (! isset($info['units'])) {
-			api_error(412, 'Units is required');
-		}
-		if (! isset($info['mb_flag'])) {
-			api_error(412, 'MB Flag is required');
-		}
-		if (! isset($info['sales_account'])) {
-			api_error(412, 'Sales Account is required');
-		}
-		if (! isset($info['cogs_account'])) {
-			api_error(412, 'Cogs Account is required');
-		}
-		if (! isset($info['adjustment_account'])) {
-			api_error(412, 'Adjustment Account is required');
-		}
-		if (! isset($info['wip_account'])) {
-			api_error(412, 'Assembly Account is required');
-		}
+        // Validate Required Fields
+        if (! isset($info['stock_id'])) {
+            api_error(412, 'Stock Id is required');
+        }
+        if (! isset($info['description'])) {
+            api_error(412, 'Description is required');
+        }
+        if (! isset($info['long_description'])) {
+            $info['long_description'] = $info['description'];
+        }
+        if (! isset($info['category_id'])) {
+            api_error(412, 'Category Id is required');
+        }
+        if (! isset($info['tax_type_id'])) {
+            api_error(412, 'Tax Type is required');
+        }
+        if (! isset($info['units'])) {
+            api_error(412, 'Units is required');
+        }
+        if (! isset($info['mb_flag'])) {
+            api_error(412, 'MB Flag is required');
+        }
+        if (! isset($info['sales_account'])) {
+            api_error(412, 'Sales Account is required');
+        }
+        if (! isset($info['cogs_account'])) {
+            api_error(412, 'Cogs Account is required');
+        }
+        if (! isset($info['adjustment_account'])) {
+            api_error(412, 'Adjustment Account is required');
+        }
+        if (! isset($info['wip_account'])) {
+            api_error(412, 'Assembly Account is required');
+        }
 
-		// TODO Validate Stock Id is Unique
+        // TODO Validate Stock Id is Unique
 
-		/*
-		 * $stock_id, $description, $long_description, $category_id, $tax_type_id, $units, $mb_flag,	$sales_account,
-		 * $inventory_account, $cogs_account, $adjustment_account,	$wip_account, $dimension_id, $dimension2_id,
-		 * $no_sale, $editable
-		 */
-		add_item(
-			$info['stock_id'],
-			$info['description'],
-			$info['long_description'],
-			$info['category_id'],
-			$info['tax_type_id'],
-			$info['units'],
-			$info['mb_flag'],
-			$info['sales_account'],
-			$info['inventory_account'],
-			$info['cogs_account'],
-			$info['adjustment_account'],
-			$info['wip_account'],
-			0, // dimension 1
-			0, // dimension2
-			0, // no sale
-			1, // editable
-			0  // no purchase
-		);
+        /*
+         * $stock_id, $description, $long_description, $category_id, $tax_type_id, $units, $mb_flag,	$sales_account,
+         * $inventory_account, $cogs_account, $adjustment_account,	$wip_account, $dimension_id, $dimension2_id,
+         * $no_sale, $editable
+         */
+        add_item(
+            $info['stock_id'],
+            $info['description'],
+            $info['long_description'],
+            $info['category_id'],
+            $info['tax_type_id'],
+            $info['units'],
+            $info['mb_flag'],
+            $info['sales_account'],
+            $info['inventory_account'],
+            $info['cogs_account'],
+            $info['adjustment_account'],
+            $info['wip_account'],
+            0, // dimension 1
+            0, // dimension2
+            0, // no sale
+            1, // editable
+            0  // no purchase
+        );
 
-		$itm = get_item($info['stock_id']);
+        $itm = get_item($info['stock_id']);
 
-		if ($itm != null) {
-			api_create_response(json_encode($itm));
-		} else {
-			api_error(500, 'Could Not Save to Database');
-		}
-	}
+        if ($itm != null) {
+            api_create_response(json_encode($itm));
+        } else {
+            api_error(500, 'Could Not Save to Database');
+        }
+    }
 
-	function inventory_edit($id)
-	{
-		$app = \Slim\Slim::getInstance('SASYS');
-		$req = $app->request();
-		$info = $req->post();
+    public function inventory_edit($id)
+    {
+        $app = \Slim\Slim::getInstance('SASYS');
+        $req = $app->request();
+        $info = $req->post();
 
-		$itm = get_item($id);
-		if ($itm == null) {
-			api_error(400, 'Invalid Stock Id');
-		}
+        $itm = get_item($id);
+        if ($itm == null) {
+            api_error(400, 'Invalid Stock Id');
+        }
 
-		// Validate Required Fields
-		if (! isset($info['description'])) {
-			api_error(412, 'Description is required');
-		}
-		if (! isset($info['long_description'])) {
-			$info['long_description'] = $info['description'];
-		}
-		if (! isset($info['category_id'])) {
-			api_error(412, 'Category Id is required');
-		}
-		if (! isset($info['tax_type_id'])) {
-			api_error(412, 'Tax Type is required');
-		}
-		if (! isset($info['units'])) {
-			api_error(412, 'Units is required');
-		}
-		if (! isset($info['mb_flag'])) {
-			api_error(412, 'MB Flag is required');
-		}
-		if (! isset($info['sales_account'])) {
-			api_error(412, 'Sales Account is required');
-		}
-		if (! isset($info['cogs_account'])) {
-			api_error(412, 'Cogs Account is required');
-		}
-		if (! isset($info['adjustment_account'])) {
-			api_error(412, 'Adjustment Account is required');
-		}
-		if (! isset($info['wip_account'])) {
-			api_error(412, 'WIP Account is required');
-		}
+        // Validate Required Fields
+        if (! isset($info['description'])) {
+            api_error(412, 'Description is required');
+        }
+        if (! isset($info['long_description'])) {
+            $info['long_description'] = $info['description'];
+        }
+        if (! isset($info['category_id'])) {
+            api_error(412, 'Category Id is required');
+        }
+        if (! isset($info['tax_type_id'])) {
+            api_error(412, 'Tax Type is required');
+        }
+        if (! isset($info['units'])) {
+            api_error(412, 'Units is required');
+        }
+        if (! isset($info['mb_flag'])) {
+            api_error(412, 'MB Flag is required');
+        }
+        if (! isset($info['sales_account'])) {
+            api_error(412, 'Sales Account is required');
+        }
+        if (! isset($info['cogs_account'])) {
+            api_error(412, 'Cogs Account is required');
+        }
+        if (! isset($info['adjustment_account'])) {
+            api_error(412, 'Adjustment Account is required');
+        }
+        if (! isset($info['wip_account'])) {
+            api_error(412, 'WIP Account is required');
+        }
 
-		/*
-		 * $stock_id, $description, $long_description, $category_id, $tax_type_id, $units='', $mb_flag='',
-		 * $sales_account, $inventory_account, $cogs_account, 	$adjustment_account, $wip_account, $dimension_id,
-		 * $dimension2_id, $no_sale, $editable
-		 */
-		update_item(
-			$info['stock_id'],
-			$info['description'],
-			$info['long_description'],
-			$info['category_id'],
-			$info['tax_type_id'],
-			$info['units'],
-			$info['mb_flag'],
-			$info['sales_account'],
-			$info['inventory_account'],
-			$info['cogs_account'],
-			$info['adjustment_account'],
-			$info['wip_account'],
-			0, // dimension 1
-			0, // dimension2
-			0, // no sale
-			1, // editable
-			0  // no purchase
-		);
+        /*
+         * $stock_id, $description, $long_description, $category_id, $tax_type_id, $units='', $mb_flag='',
+         * $sales_account, $inventory_account, $cogs_account, 	$adjustment_account, $wip_account, $dimension_id,
+         * $dimension2_id, $no_sale, $editable
+         */
+        update_item(
+            $info['stock_id'],
+            $info['description'],
+            $info['long_description'],
+            $info['category_id'],
+            $info['tax_type_id'],
+            $info['units'],
+            $info['mb_flag'],
+            $info['sales_account'],
+            $info['inventory_account'],
+            $info['cogs_account'],
+            $info['adjustment_account'],
+            $info['wip_account'],
+            0, // dimension 1
+            0, // dimension2
+            0, // no sale
+            1, // editable
+            0  // no purchase
+        );
 
-		api_success_response("Item has been updated");
-	}
+        api_success_response("Item has been updated");
+    }
 
-	function inventory_delete($id)
-	{
-		$app = \Slim\Slim::getInstance('SASYS');
-		$req = $app->request();
-		$info = $req->post();
+    public function inventory_delete($id)
+    {
+        $app = \Slim\Slim::getInstance('SASYS');
+        $req = $app->request();
+        $info = $req->post();
 
-		$itm = get_item($id);
-		if ($itm == null) {
-			api_error(400, 'Invalid Stock Id');
-		}
+        $itm = get_item($id);
+        if ($itm == null) {
+            api_error(400, 'Invalid Stock Id');
+        }
 
-		delete_item($id);
+        delete_item($id);
 
-		$itm = get_item($id);
+        $itm = get_item($id);
 
-		if ($itm != null) {
-			api_error(500, 'Could Not Delete from Database');
-		} else {
-			api_success_response("Item has been deleted");
-		}
-	}
-
-
+        if ($itm != null) {
+            api_error(500, 'Could Not Delete from Database');
+        } else {
+            api_success_response("Item has been deleted");
+        }
+    }
 }

--- a/src/InventoryCosts.php
+++ b/src/InventoryCosts.php
@@ -8,30 +8,30 @@ include_once($path_to_root . "/inventory/includes/db/items_trans_db.inc");
 
 class InventoryCosts
 {
-	// Get Specific Item by Stock Id
-	public function getById($rest, $id)
-	{
-		$cost = get_unit_cost($id);
-		api_success_response(json_encode( array('stock_id' => $id, 'unit_cost' => $cost) ));
-	}
-	// Edit Specific Item
-	public function put($rest, $id)
-	{
-		$req = $rest->request();
-		$info = $req->post();
+    // Get Specific Item by Stock Id
+    public function getById($rest, $id)
+    {
+        $cost = get_unit_cost($id);
+        api_success_response(json_encode(array('stock_id' => $id, 'unit_cost' => $cost)));
+    }
+    // Edit Specific Item
+    public function put($rest, $id)
+    {
+        $req = $rest->request();
+        $info = $req->post();
 
-		$old_cost = get_unit_cost($id);
+        $old_cost = get_unit_cost($id);
 
-		$update_no = stock_cost_update(
-			$id,
-			$info['material_cost'],
-			$info['labour_cost'],
-			$info['overhead_cost'],
-			$old_cost,
-			'', // Ref lines
-			''  // Memo
-		);
+        $update_no = stock_cost_update(
+            $id,
+            $info['material_cost'],
+            $info['labour_cost'],
+            $info['overhead_cost'],
+            $old_cost,
+            '', // Ref lines
+            ''  // Memo
+        );
 
-		api_success_response(json_encode( array('stock_id' => $id)));
-	}
+        api_success_response(json_encode(array('stock_id' => $id)));
+    }
 }

--- a/src/InventoryLocations.php
+++ b/src/InventoryLocations.php
@@ -3,78 +3,77 @@ namespace FAAPI;
 
 $path_to_root = "../..";
 
-include_once ($path_to_root . "/inventory/includes/inventory_db.inc");
-include_once ($path_to_root . "/inventory/includes/db/items_codes_db.inc");
-include_once ($path_to_root . "/inventory/includes/db/items_locations_db.inc");
-include_once ($path_to_root . "/gl/includes/gl_db.inc");
-include_once ($path_to_root . "/includes/ui/items_cart.inc");
+include_once($path_to_root . "/inventory/includes/inventory_db.inc");
+include_once($path_to_root . "/inventory/includes/db/items_codes_db.inc");
+include_once($path_to_root . "/inventory/includes/db/items_locations_db.inc");
+include_once($path_to_root . "/gl/includes/gl_db.inc");
+include_once($path_to_root . "/includes/ui/items_cart.inc");
 
 class InventoryLocations
 {
-	// Get Items
-	public function get($rest)
-	{
-		$locations = get_item_locations(false);
-		$ret = array();
-		while ($loc = db_fetch($locations)) {
-			$ret[] = array(
-				'loc_code' => $loc['loc_code'],
-				'location_name' => $loc['location_name'],
-				'delivery_address' => $loc['delivery_address'],
-				'phone' => $loc['phone'],
-				'phone2' => $loc['phone2'],
-				'fax' => $loc['fax'],
-				'email' => $loc['email'],
-				'contact' => $loc['contact']
-			);
-		}
-		api_success_response(json_encode($ret));
-	}
+    // Get Items
+    public function get($rest)
+    {
+        $locations = get_item_locations(false);
+        $ret = array();
+        while ($loc = db_fetch($locations)) {
+            $ret[] = array(
+                'loc_code' => $loc['loc_code'],
+                'location_name' => $loc['location_name'],
+                'delivery_address' => $loc['delivery_address'],
+                'phone' => $loc['phone'],
+                'phone2' => $loc['phone2'],
+                'fax' => $loc['fax'],
+                'email' => $loc['email'],
+                'contact' => $loc['contact']
+            );
+        }
+        api_success_response(json_encode($ret));
+    }
 
-	// Add Item
-	public function post($rest)
-	{
-		// Originally added by Richard Vinke
-		$req = $rest->request();
-		$info = $req->post();
+    // Add Item
+    public function post($rest)
+    {
+        // Originally added by Richard Vinke
+        $req = $rest->request();
+        $info = $req->post();
 
-		// ToDo Check if loc_code already exists
+        // ToDo Check if loc_code already exists
 
-		// Validate Required Fields
-		if (! isset($info['loc_code'])) {
-			api_error(412, 'Stock Id is required');
-		}
-		if (! isset($info['location_name'])) {
-			api_error(412, 'Stock Id is required');
-		}
-		if (! isset($info['delivery_address'])) {
-			$info['delivery_address'] = '';
-		}
-		if (! isset($info['phone'])) {
-			$info['phone'] = '';
-		}
-		if (! isset($info['phone2'])) {
-			$info['phone2'] = '';
-		}
-		if (! isset($info['fax'])) {
-			$info['fax'] = '';
-		}
-		if (! isset($info['email'])) {
-			$info['email'] = '';
-		}
-		if (! isset($info['contact'])) {
-			$info['contact'] = '';
-		}
+        // Validate Required Fields
+        if (! isset($info['loc_code'])) {
+            api_error(412, 'Stock Id is required');
+        }
+        if (! isset($info['location_name'])) {
+            api_error(412, 'Stock Id is required');
+        }
+        if (! isset($info['delivery_address'])) {
+            $info['delivery_address'] = '';
+        }
+        if (! isset($info['phone'])) {
+            $info['phone'] = '';
+        }
+        if (! isset($info['phone2'])) {
+            $info['phone2'] = '';
+        }
+        if (! isset($info['fax'])) {
+            $info['fax'] = '';
+        }
+        if (! isset($info['email'])) {
+            $info['email'] = '';
+        }
+        if (! isset($info['contact'])) {
+            $info['contact'] = '';
+        }
 
-		add_item_location($info['loc_code'], $info['location_name'], $info['delivery_address'], $info['phone'], $info['phone2'], $info['fax'], $info['email'], $info['contact']);
+        add_item_location($info['loc_code'], $info['location_name'], $info['delivery_address'], $info['phone'], $info['phone2'], $info['fax'], $info['email'], $info['contact']);
 
-		$itm = get_item_location($info['loc_code']);
+        $itm = get_item_location($info['loc_code']);
 
-		if ($itm != null) {
-			api_create_response(json_encode($itm));
-		} else {
-			api_error(500, 'Could Not Save to Database');
-		}
-	}
-
+        if ($itm != null) {
+            api_create_response(json_encode($itm));
+        } else {
+            api_error(500, 'Could Not Save to Database');
+        }
+    }
 }

--- a/src/Sales.php
+++ b/src/Sales.php
@@ -1,10 +1,41 @@
 <?php
 namespace FAAPI;
-
+/**
+ * @SWG\Definition(
+ *   definition="Sale",
+ *   type="object",
+ *   format="",
+ *   description="A Sale",
+ *   @SWG\Property(
+ *     property="id",
+ *     type="integer",
+ *     description="Unique id used to reference a Sale",
+ *     example="1"
+ *   )
+ * )
+ */
 class Sales
 {
 	// Get Items
-	public function get($rest, $trans_type)
+    /**
+     * @SWG\Get(
+     *     path="/sales",
+     *     summary="List Sales",
+     *     tags={"sales"},
+     *     operationId="getSales",
+     *     produces={"application/json"},
+     *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="object",
+     *             ref="#/definitions/Sale"
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
+	 public function get($rest, $trans_type)
 	{
 		$req = $rest->request();
 		include_once (API_ROOT . "/sales.inc");
@@ -20,19 +51,73 @@ class Sales
 		}
 	}
 
-	// Get Specific Item by Stock Id
+	// Get Specific Item by Sale Id
+    /**
+     * @SWG\Get(
+     *     path="/sales/id",
+     *     summary="Fetch Sale by id",
+     *     tags={"sales"},
+     *     operationId="getSale",
+     *     produces={"application/json"},
+     *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="object",
+     *             ref="#/definitions/Sale"
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
 	public function getById($rest, $trans_no, $trans_type)
 	{
 		include_once (API_ROOT . "/sales.inc");
 		sales_get($trans_no, $trans_type);
 	}
 	// Add Item
-	public function post($rest)
+    /**
+     * @SWG\Post(
+     *     path="/sales",
+     *     summary="Add Sale",
+     *     tags={"sales"},
+     *     operationId="addSale",
+     *     produces={"application/json"},
+     *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="object",
+     *             ref="#/definitions/Sale"
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
+	 public function post($rest)
 	{
 		include_once (API_ROOT . "/sales.inc");
 		sales_add();
 	}
 	// Edit Specific Item
+    /**
+     * @SWG\Put(
+     *     path="/sales",
+     *     summary="Update Sale",
+     *     tags={"sales"},
+     *     operationId="addSale",
+     *     produces={"application/json"},
+     *     @SWG\Response(
+     *         response=200,
+     *         description="successful operation",
+     *         @SWG\Schema(
+     *             type="object",
+     *             ref="#/definitions/Sale"
+     *         )
+     *     ),
+     *     deprecated=false
+     * )
+     */
 	public function put($rest, $trans_no, $trans_type)
 	{
 		include_once (API_ROOT . "/sales.inc");

--- a/src/Sales.php
+++ b/src/Sales.php
@@ -1,5 +1,6 @@
 <?php
 namespace FAAPI;
+
 /**
  * @SWG\Definition(
  *   definition="Sale",
@@ -16,7 +17,7 @@ namespace FAAPI;
  */
 class Sales
 {
-	// Get Items
+    // Get Items
     /**
      * @SWG\Get(
      *     path="/sales",
@@ -35,23 +36,23 @@ class Sales
      *     deprecated=false
      * )
      */
-	 public function get($rest, $trans_type)
-	{
-		$req = $rest->request();
-		include_once (API_ROOT . "/sales.inc");
+    public function get($rest, $trans_type)
+    {
+        $req = $rest->request();
+        include_once(API_ROOT . "/sales.inc");
 
-		$page = $req->get("page");
+        $page = $req->get("page");
 
-		if ($page == null) {
-			sales_all($trans_type);
-		} else {
-			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
-			$from = -- $page * RESULTS_PER_PAGE;
-			sales_all($trans_type, $from);
-		}
-	}
+        if ($page == null) {
+            sales_all($trans_type);
+        } else {
+            // If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+            $from = -- $page * RESULTS_PER_PAGE;
+            sales_all($trans_type, $from);
+        }
+    }
 
-	// Get Specific Item by Sale Id
+    // Get Specific Item by Sale Id
     /**
      * @SWG\Get(
      *     path="/sales/id",
@@ -70,12 +71,12 @@ class Sales
      *     deprecated=false
      * )
      */
-	public function getById($rest, $trans_no, $trans_type)
-	{
-		include_once (API_ROOT . "/sales.inc");
-		sales_get($trans_no, $trans_type);
-	}
-	// Add Item
+    public function getById($rest, $trans_no, $trans_type)
+    {
+        include_once(API_ROOT . "/sales.inc");
+        sales_get($trans_no, $trans_type);
+    }
+    // Add Item
     /**
      * @SWG\Post(
      *     path="/sales",
@@ -94,12 +95,12 @@ class Sales
      *     deprecated=false
      * )
      */
-	 public function post($rest)
-	{
-		include_once (API_ROOT . "/sales.inc");
-		sales_add();
-	}
-	// Edit Specific Item
+    public function post($rest)
+    {
+        include_once(API_ROOT . "/sales.inc");
+        sales_add();
+    }
+    // Edit Specific Item
     /**
      * @SWG\Put(
      *     path="/sales",
@@ -118,15 +119,15 @@ class Sales
      *     deprecated=false
      * )
      */
-	public function put($rest, $trans_no, $trans_type)
-	{
-		include_once (API_ROOT . "/sales.inc");
-		sales_edit($trans_no, $trans_type);
-	}
-	// Delete Specific Item
-	public function delete($rest, $branch_id, $uuid)
-	{
-		include_once (API_ROOT . "/sales.inc");
-		sales_cancel($branch_id, $uuid);
-	}
+    public function put($rest, $trans_no, $trans_type)
+    {
+        include_once(API_ROOT . "/sales.inc");
+        sales_edit($trans_no, $trans_type);
+    }
+    // Delete Specific Item
+    public function delete($rest, $branch_id, $uuid)
+    {
+        include_once(API_ROOT . "/sales.inc");
+        sales_cancel($branch_id, $uuid);
+    }
 }

--- a/src/Suppliers.php
+++ b/src/Suppliers.php
@@ -3,219 +3,220 @@ namespace FAAPI;
 
 $path_to_root = "../..";
 
-include_once ($path_to_root . "/purchasing/includes/db/suppliers_db.inc");
-include_once ($path_to_root . "/includes/db/crm_contacts_db.inc");
+include_once($path_to_root . "/purchasing/includes/db/suppliers_db.inc");
+include_once($path_to_root . "/includes/db/crm_contacts_db.inc");
 
 class Suppliers
 {
-	// Get Items
-	public function get($rest)
-	{
-		$req = $rest->request();
-		$page = $req->get("page");
+    // Get Items
+    public function get($rest)
+    {
+        $req = $rest->request();
+        $page = $req->get("page");
 
-		$this->supplier_all($page);
-	}
+        $this->supplier_all($page);
+    }
 
-	// Get Specific Item by Stock Id
-	public function getById($rest, $id)
-	{
-		$sup = get_supplier($id);
-		api_success_response(json_encode(api_ensureAssociativeArray($sup)));
-	}
+    // Get Specific Item by Stock Id
+    public function getById($rest, $id)
+    {
+        $sup = get_supplier($id);
+        api_success_response(json_encode(api_ensureAssociativeArray($sup)));
+    }
 
-	// Add Item
-	public function post($rest)
-	{
-		$req = $rest->request();
-		$info = $req->post();
+    // Add Item
+    public function post($rest)
+    {
+        $req = $rest->request();
+        $info = $req->post();
 
-		// Validate Required Fields
-		if (! isset($info['supp_name'])) {
-			api_error(412, 'Supplier Name is required [supp_name]');
-		}
-		if (! isset($info['supp_ref'])) {
-			api_error(412, 'Supplier Reference is required [supp_ref]');
-		}
-		if (! isset($info['address'])) {
-			api_error(412, 'Address is required [address]');
-		}
-		if (! isset($info['supp_address'])) {
-			api_error(412, 'Supplier Address 2 is required [supp_address]');
-		}
-		if (! isset($info['gst_no'])) {
-			api_error(412, 'GST No. is required [gst_no]');
-		}
-		if (! isset($info['supp_account_no'])) {
-			api_error(412, 'Supplier Account Number is required [supp_account_no]');
-		}
-		if (! isset($info['bank_account'])) {
-			api_error(412, 'Bank Account is required [bank_account]');
-		}
-		if (! isset($info['credit_limit'])) {
-			api_error(412, 'Credit Limir is required [credit_limit]');
-		}
-		if (! isset($info['curr_code'])) {
-			api_error(412, 'Currency Code is required [curr_code]');
-		}
-		if (! isset($info['payment_terms'])) {
-			api_error(412, 'Payment Terms is required [payment_terms]');
-		}
-		if (! isset($info['payable_account'])) {
-			api_error(412, 'Payable Account is required [payable_account]');
-		}
-		if (! isset($info['purchase_account'])) {
-			api_error(412, 'Purchase Account is required [purchase_account]');
-		}
-		if (! isset($info['payment_discount_account'])) {
-			api_error(412, 'Payment Discount Account is required [payment_discount]');
-		}
-		if (! isset($info['tax_group_id'])) {
-			api_error(412, 'Tax Group Id is required [tax_group_id]');
-		}
-		if (! isset($info['tax_included'])) {
-			api_error(412, 'Tax Included is required [tax_included]');
-		}
-		if (! isset($info['website'])) {
-			$info['website'] = '';
-		}
-		if (! isset($info['notes'])) {
-			$info['notes'] = '';
-		}
+        // Validate Required Fields
+        if (! isset($info['supp_name'])) {
+            api_error(412, 'Supplier Name is required [supp_name]');
+        }
+        if (! isset($info['supp_ref'])) {
+            api_error(412, 'Supplier Reference is required [supp_ref]');
+        }
+        if (! isset($info['address'])) {
+            api_error(412, 'Address is required [address]');
+        }
+        if (! isset($info['supp_address'])) {
+            api_error(412, 'Supplier Address 2 is required [supp_address]');
+        }
+        if (! isset($info['gst_no'])) {
+            api_error(412, 'GST No. is required [gst_no]');
+        }
+        if (! isset($info['supp_account_no'])) {
+            api_error(412, 'Supplier Account Number is required [supp_account_no]');
+        }
+        if (! isset($info['bank_account'])) {
+            api_error(412, 'Bank Account is required [bank_account]');
+        }
+        if (! isset($info['credit_limit'])) {
+            api_error(412, 'Credit Limir is required [credit_limit]');
+        }
+        if (! isset($info['curr_code'])) {
+            api_error(412, 'Currency Code is required [curr_code]');
+        }
+        if (! isset($info['payment_terms'])) {
+            api_error(412, 'Payment Terms is required [payment_terms]');
+        }
+        if (! isset($info['payable_account'])) {
+            api_error(412, 'Payable Account is required [payable_account]');
+        }
+        if (! isset($info['purchase_account'])) {
+            api_error(412, 'Purchase Account is required [purchase_account]');
+        }
+        if (! isset($info['payment_discount_account'])) {
+            api_error(412, 'Payment Discount Account is required [payment_discount]');
+        }
+        if (! isset($info['tax_group_id'])) {
+            api_error(412, 'Tax Group Id is required [tax_group_id]');
+        }
+        if (! isset($info['tax_included'])) {
+            api_error(412, 'Tax Included is required [tax_included]');
+        }
+        if (! isset($info['website'])) {
+            $info['website'] = '';
+        }
+        if (! isset($info['notes'])) {
+            $info['notes'] = '';
+        }
 
-		/*
-		 * $supp_name, $supp_ref, $address, $supp_address, $gst_no, $website, $supp_account_no, $bank_account,
-		 * $credit_limit, $dimension_id, $dimension2_id, $curr_code, $payment_terms, $payable_account,
-		 * $purchase_account, $payment_discount_account, $notes, $tax_group_id, $tax_included
-		 */
-		add_supplier($info['supp_name'], $info['supp_ref'], $info['address'], $info['supp_address'], $info['gst_no'], $info['website'], $info['supp_account_no'], $info['bank_account'], $info['credit_limit'], 0, 0, $info['curr_code'], $info['payment_terms'], $info['payable_account'], $info['purchase_account'], $info['payment_discount_account'], $info['notes'], $info['tax_group_id'], $info['tax_included']);
+        /*
+         * $supp_name, $supp_ref, $address, $supp_address, $gst_no, $website, $supp_account_no, $bank_account,
+         * $credit_limit, $dimension_id, $dimension2_id, $curr_code, $payment_terms, $payable_account,
+         * $purchase_account, $payment_discount_account, $notes, $tax_group_id, $tax_included
+         */
+        add_supplier($info['supp_name'], $info['supp_ref'], $info['address'], $info['supp_address'], $info['gst_no'], $info['website'], $info['supp_account_no'], $info['bank_account'], $info['credit_limit'], 0, 0, $info['curr_code'], $info['payment_terms'], $info['payable_account'], $info['purchase_account'], $info['payment_discount_account'], $info['notes'], $info['tax_group_id'], $info['tax_included']);
 
-		$id = db_insert_id();
-		$sup = get_supplier($id);
+        $id = db_insert_id();
+        $sup = get_supplier($id);
 
-		if ($sup != null) {
-			api_create_response(json_encode($sup));
-		} else {
-			api_error(500, 'Could Not Save to Database');
-		}
-	}
-	// Edit Specific Item
-	public function put($rest, $id)
-	{
-		$req = $rest->request();
-		$info = $req->post();
+        if ($sup != null) {
+            api_create_response(json_encode($sup));
+        } else {
+            api_error(500, 'Could Not Save to Database');
+        }
+    }
+    // Edit Specific Item
+    public function put($rest, $id)
+    {
+        $req = $rest->request();
+        $info = $req->post();
 
-		$sup = get_supplier($id);
-		if ($sup == null) {
-			api_error(400, 'Invalid Supplier ID');
-		}
+        $sup = get_supplier($id);
+        if ($sup == null) {
+            api_error(400, 'Invalid Supplier ID');
+        }
 
-		// Validate Required Fields
-		if (! isset($info['supp_name'])) {
-			api_error(412, 'Supplier Name is required [supp_name]');
-		}
-		if (! isset($info['supp_ref'])) {
-			api_error(412, 'Supplier Reference is required [supp_ref]');
-		}
-		if (! isset($info['address'])) {
-			api_error(412, 'Address is required [address]');
-		}
-		if (! isset($info['supp_address'])) {
-			api_error(412, 'Supplier Address 2 is required [supp_address]');
-		}
-		if (! isset($info['gst_no'])) {
-			api_error(412, 'GST No. is required [gst_no]');
-		}
-		if (! isset($info['supp_account_no'])) {
-			api_error(412, 'Supplier Account Number is required [supp_account_no]');
-		}
-		if (! isset($info['bank_account'])) {
-			api_error(412, 'Bank Account is required [bank_account]');
-		}
-		if (! isset($info['credit_limit'])) {
-			api_error(412, 'Credit Limir is required [credit_limit]');
-		}
-		if (! isset($info['curr_code'])) {
-			api_error(412, 'Currency Code is required [curr_code]');
-		}
-		if (! isset($info['payment_terms'])) {
-			api_error(412, 'Payment Terms is required [payment_terms]');
-		}
-		if (! isset($info['payable_account'])) {
-			api_error(412, 'Payable Account is required [payable_account]');
-		}
-		if (! isset($info['purchase_account'])) {
-			api_error(412, 'Purchase Account is required [purchase_account]');
-		}
-		if (! isset($info['payment_discount_account'])) {
-			api_error(412, 'Payment Discount Account is required [payment_discount]');
-		}
-		if (! isset($info['tax_group_id'])) {
-			api_error(412, 'Tax Group Id is required [tax_group_id]');
-		}
-		if (! isset($info['tax_included'])) {
-			api_error(412, 'Tax Included is required [tax_included]');
-		}
-		if (! isset($info['website'])) {
-			$info['website'] = '';
-		}
-		if (! isset($info['notes'])) {
-			$info['notes'] = '';
-		}
+        // Validate Required Fields
+        if (! isset($info['supp_name'])) {
+            api_error(412, 'Supplier Name is required [supp_name]');
+        }
+        if (! isset($info['supp_ref'])) {
+            api_error(412, 'Supplier Reference is required [supp_ref]');
+        }
+        if (! isset($info['address'])) {
+            api_error(412, 'Address is required [address]');
+        }
+        if (! isset($info['supp_address'])) {
+            api_error(412, 'Supplier Address 2 is required [supp_address]');
+        }
+        if (! isset($info['gst_no'])) {
+            api_error(412, 'GST No. is required [gst_no]');
+        }
+        if (! isset($info['supp_account_no'])) {
+            api_error(412, 'Supplier Account Number is required [supp_account_no]');
+        }
+        if (! isset($info['bank_account'])) {
+            api_error(412, 'Bank Account is required [bank_account]');
+        }
+        if (! isset($info['credit_limit'])) {
+            api_error(412, 'Credit Limir is required [credit_limit]');
+        }
+        if (! isset($info['curr_code'])) {
+            api_error(412, 'Currency Code is required [curr_code]');
+        }
+        if (! isset($info['payment_terms'])) {
+            api_error(412, 'Payment Terms is required [payment_terms]');
+        }
+        if (! isset($info['payable_account'])) {
+            api_error(412, 'Payable Account is required [payable_account]');
+        }
+        if (! isset($info['purchase_account'])) {
+            api_error(412, 'Purchase Account is required [purchase_account]');
+        }
+        if (! isset($info['payment_discount_account'])) {
+            api_error(412, 'Payment Discount Account is required [payment_discount]');
+        }
+        if (! isset($info['tax_group_id'])) {
+            api_error(412, 'Tax Group Id is required [tax_group_id]');
+        }
+        if (! isset($info['tax_included'])) {
+            api_error(412, 'Tax Included is required [tax_included]');
+        }
+        if (! isset($info['website'])) {
+            $info['website'] = '';
+        }
+        if (! isset($info['notes'])) {
+            $info['notes'] = '';
+        }
 
-		/*
-		 * $supplier_id, $supp_name, $supp_ref, $address, $supp_address, $gst_no, $website, $supp_account_no,
-		 * $bank_account, $credit_limit, $dimension_id, $dimension2_id, $curr_code, $payment_terms, $payable_account,
-		 * $purchase_account, $payment_discount_account, $notes, $tax_group_id, $tax_included
-		 */
-		update_supplier($id, $info['supp_name'], $info['supp_ref'], $info['address'], $info['supp_address'], $info['gst_no'], $info['website'], $info['supp_account_no'], $info['bank_account'], $info['credit_limit'], 0, 0, $info['curr_code'], $info['payment_terms'], $info['payable_account'], $info['purchase_account'], $info['payment_discount_account'], $info['notes'], $info['tax_group_id'], $info['tax_included']);
+        /*
+         * $supplier_id, $supp_name, $supp_ref, $address, $supp_address, $gst_no, $website, $supp_account_no,
+         * $bank_account, $credit_limit, $dimension_id, $dimension2_id, $curr_code, $payment_terms, $payable_account,
+         * $purchase_account, $payment_discount_account, $notes, $tax_group_id, $tax_included
+         */
+        update_supplier($id, $info['supp_name'], $info['supp_ref'], $info['address'], $info['supp_address'], $info['gst_no'], $info['website'], $info['supp_account_no'], $info['bank_account'], $info['credit_limit'], 0, 0, $info['curr_code'], $info['payment_terms'], $info['payable_account'], $info['purchase_account'], $info['payment_discount_account'], $info['notes'], $info['tax_group_id'], $info['tax_included']);
 
-		api_success_response("Supplier has been updated");
-	}
-	// Delete Specific Item
-	public function delete($rest, $id)
-	{
-		$req = $rest->request();
-		$info = $req->post();
+        api_success_response("Supplier has been updated");
+    }
+    // Delete Specific Item
+    public function delete($rest, $id)
+    {
+        $req = $rest->request();
+        $info = $req->post();
 
-		$sup = get_supplier($id);
-		if ($sup == null) {
-			api_error(400, 'Invalid Supplier ID');
-		}
+        $sup = get_supplier($id);
+        if ($sup == null) {
+            api_error(400, 'Invalid Supplier ID');
+        }
 
-		delete_supplier($id);
+        delete_supplier($id);
 
-		$sup = null;
-		$sup = get_supplier($id);
+        $sup = null;
+        $sup = get_supplier($id);
 
-		if ($sup != null) {
-			api_error(500, 'Could Not Delete from Database');
-		} else {
-			api_success_response("Supplier has been deleted");
-		}
-	}
+        if ($sup != null) {
+            api_error(500, 'Could Not Delete from Database');
+        } else {
+            api_success_response("Supplier has been deleted");
+        }
+    }
 
-	public function getContacts($rest, $id)
-	{
-		$contacts = get_supplier_contacts($id, null);
-		api_success_response(json_encode($contacts));
-	}
+    public function getContacts($rest, $id)
+    {
+        $contacts = get_supplier_contacts($id, null);
+        api_success_response(json_encode($contacts));
+    }
 
-	private function supplier_all($from = null)
-	{
-		if ($from == null)
-			$from = 0;
+    private function supplier_all($from = null)
+    {
+        if ($from == null) {
+            $from = 0;
+        }
 
-		$sql = "SELECT * FROM " . TB_PREF . "suppliers LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+        $sql = "SELECT * FROM " . TB_PREF . "suppliers LIMIT " . $from . ", " . RESULTS_PER_PAGE;
 
-		$query = db_query($sql, "error");
+        $query = db_query($sql, "error");
 
-		$info = array();
+        $info = array();
 
-		while ($data = db_fetch_assoc($query, "error")) {
-			$info[] = $data;
-		}
+        while ($data = db_fetch_assoc($query, "error")) {
+            $info[] = $data;
+        }
 
-		api_success_response(json_encode($info));
-	}
+        api_success_response(json_encode($info));
+    }
 }

--- a/src/TaxGroups.php
+++ b/src/TaxGroups.php
@@ -3,45 +3,46 @@ namespace FAAPI;
 
 $path_to_root = "../..";
 
-include_once ($path_to_root . "/taxes/db/tax_groups_db.inc");
+include_once($path_to_root . "/taxes/db/tax_groups_db.inc");
 
 class TaxGroups
 {
-	// Get Items
-	public function get($rest)
-	{
-		$req = $rest->request();
+    // Get Items
+    public function get($rest)
+    {
+        $req = $rest->request();
 
-		$page = $req->get("page");
+        $page = $req->get("page");
 
-		if ($page == null) {
-			$this->taxgroups_all();
-		} else {
-			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
-			$from = -- $page * RESULTS_PER_PAGE;
-			$this->taxgroups_all($from);
-		}
-	}
+        if ($page == null) {
+            $this->taxgroups_all();
+        } else {
+            // If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+            $from = -- $page * RESULTS_PER_PAGE;
+            $this->taxgroups_all($from);
+        }
+    }
 
-	private function taxgroups_all($from = null)
-	{
-		if ($from == null)
-			$from = 0;
+    private function taxgroups_all($from = null)
+    {
+        if ($from == null) {
+            $from = 0;
+        }
 
-		$sql = "SELECT * FROM " . TB_PREF . "tax_groups WHERE !inactive LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+        $sql = "SELECT * FROM " . TB_PREF . "tax_groups WHERE !inactive LIMIT " . $from . ", " . RESULTS_PER_PAGE;
 
-		$query = db_query($sql, "error");
+        $query = db_query($sql, "error");
 
-		$info = array();
+        $info = array();
 
-		while ($data = db_fetch($query, "error")) {
-			$info[] = array(
-				'id' => $data['id'],
-				'name' => $data['name'],
-				'inactive' => $data['inactive']
-			);
-		}
+        while ($data = db_fetch($query, "error")) {
+            $info[] = array(
+                'id' => $data['id'],
+                'name' => $data['name'],
+                'inactive' => $data['inactive']
+            );
+        }
 
-		api_success_response(json_encode($info));
-	}
+        api_success_response(json_encode($info));
+    }
 }

--- a/src/TaxTypes.php
+++ b/src/TaxTypes.php
@@ -3,55 +3,57 @@ namespace FAAPI;
 
 $path_to_root = "../..";
 
-include_once ($path_to_root . "/taxes/db/item_tax_types_db.inc");
-include_once ($path_to_root . "/taxes/db/tax_types_db.inc");
+include_once($path_to_root . "/taxes/db/item_tax_types_db.inc");
+include_once($path_to_root . "/taxes/db/tax_types_db.inc");
 
 class TaxTypes
 {
-	// Get TaxTypes
-	public function get($rest)
-	{
-		$req = $rest->request();
+    // Get TaxTypes
+    public function get($rest)
+    {
+        $req = $rest->request();
 
-		$page = $req->get("page");
+        $page = $req->get("page");
 
-		if ($page == null) {
-			$this->taxtypes_all();
-		} else {
-			// If page = 1 the value will be 0, if page = 2 the value will be 1, ...
-			$from = -- $page * RESULTS_PER_PAGE;
-			$this->taxtypes_all($from);
-		}
-	}
+        if ($page == null) {
+            $this->taxtypes_all();
+        } else {
+            // If page = 1 the value will be 0, if page = 2 the value will be 1, ...
+            $from = -- $page * RESULTS_PER_PAGE;
+            $this->taxtypes_all($from);
+        }
+    }
 
-	// Get TaxType by Id
-	public function getById($rest, $id) {
-		$taxType = get_tax_type($id);
-		if (!$taxType) {
-			$taxType = array();
-		}
-		api_success_response(json_encode(\api_ensureAssociativeArray($taxType)));
-	}
+    // Get TaxType by Id
+    public function getById($rest, $id)
+    {
+        $taxType = get_tax_type($id);
+        if (!$taxType) {
+            $taxType = array();
+        }
+        api_success_response(json_encode(\api_ensureAssociativeArray($taxType)));
+    }
 
-	private function taxtypes_all($from = null)
-	{
-		if ($from == null)
-			$from = 0;
+    private function taxtypes_all($from = null)
+    {
+        if ($from == null) {
+            $from = 0;
+        }
 
-		$sql = "SELECT * FROM " . TB_PREF . "item_tax_types LIMIT " . $from . ", " . RESULTS_PER_PAGE;
+        $sql = "SELECT * FROM " . TB_PREF . "item_tax_types LIMIT " . $from . ", " . RESULTS_PER_PAGE;
 
-		$query = db_query($sql, "error");
+        $query = db_query($sql, "error");
 
-		$info = array();
+        $info = array();
 
-		while ($data = db_fetch($query, "error")) {
-			$info[] = array(
-				'id' => $data['id'],
-				'name' => $data['name'],
-				'exempt' => $data['exempt']
-			);
-		}
+        while ($data = db_fetch($query, "error")) {
+            $info[] = array(
+                'id' => $data['id'],
+                'name' => $data['name'],
+                'exempt' => $data['exempt']
+            );
+        }
 
-		api_success_response(json_encode($info));
-	}
+        api_success_response(json_encode($info));
+    }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,238 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Front Accounting Simple API",
+        "description": "This is a simple REST API as a Front Accounting module [https://github.com/cambell-prince/FrontAccountingSimpleAPI](https://github.com/cambell-prince/FrontAccountingSimpleAPI).",
+        "contact": {
+            "email": "cambell.prince@gmail.com"
+        },
+        "license": {
+            "name": "GPL V2.0",
+            "url": "https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html"
+        },
+        "version": "2.4-1.2"
+    },
+    "host": "frontaccounting.demo.saygoweb.com",
+    "basePath": "/modules/api",
+    "paths": {
+        "/bankaccounts": {
+            "get": {
+                "tags": [
+                    "bank account"
+                ],
+                "summary": "List Bank Accounts",
+                "operationId": "listBankAccounts",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BankAccount"
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/bankaccounts/id": {
+            "get": {
+                "tags": [
+                    "bank account"
+                ],
+                "summary": "Fetch Bank Account by id",
+                "operationId": "getBankAccount",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/BankAccount"
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/sales": {
+            "get": {
+                "tags": [
+                    "sales"
+                ],
+                "summary": "List Sales",
+                "operationId": "getSales",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/Sale"
+                        }
+                    }
+                },
+                "deprecated": false
+            },
+            "put": {
+                "tags": [
+                    "sales"
+                ],
+                "summary": "Update Sale",
+                "operationId": "addSale",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/Sale"
+                        }
+                    }
+                },
+                "deprecated": false
+            },
+            "post": {
+                "tags": [
+                    "sales"
+                ],
+                "summary": "Add Sale",
+                "operationId": "addSale",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/Sale"
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/sales/id": {
+            "get": {
+                "tags": [
+                    "sales"
+                ],
+                "summary": "Fetch Sale by id",
+                "operationId": "getSale",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/Sale"
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        }
+    },
+    "definitions": {
+        "BankAccount": {
+            "description": "A Bank Account",
+            "properties": {
+                "id": {
+                    "description": "Unique id used to reference a Bank Account",
+                    "type": "integer",
+                    "example": "1"
+                },
+                "account_code": {
+                    "description": "Account GL code",
+                    "type": "string",
+                    "example": "1060"
+                },
+                "account_type": {
+                    "description": "Type of the account",
+                    "type": "integer",
+                    "example": "0"
+                },
+                "bank_name": {
+                    "description": "Name of the bank at which this account is held",
+                    "type": "string",
+                    "example": "Some Bank"
+                },
+                "bank_address": {
+                    "description": "Address of the Bank",
+                    "type": "string"
+                },
+                "bank_account_name": {
+                    "description": "Name of the account",
+                    "type": "string",
+                    "example": "Anne X Ample"
+                },
+                "bank_account_number": {
+                    "description": "Account number used by the Bank",
+                    "type": "string",
+                    "example": "12-3456-7890-1"
+                },
+                "bank_curr_code": {
+                    "description": "Currency of the account",
+                    "type": "string",
+                    "example": "USD"
+                },
+                "dflt_curr_act": {
+                    "description": "True (1) if this account is the default account",
+                    "type": "boolean",
+                    "example": "0"
+                },
+                "bank_charge_act": {
+                    "description": "GL account to which bank charges are assigned",
+                    "type": "string",
+                    "example": "5690"
+                },
+                "last_reconciled_date": {
+                    "description": "Date up to which this account was reconciled",
+                    "type": "date",
+                    "example": "2017-12-01"
+                },
+                "ending_reconcile_balance": {
+                    "description": "Account balance at last reconcile",
+                    "type": "number",
+                    "example": "12.34"
+                },
+                "inactive": {
+                    "description": "True if this account is not active",
+                    "type": "boolean",
+                    "example": "0"
+                }
+            },
+            "type": "object",
+            "format": ""
+        },
+        "Sale": {
+            "description": "A Sale",
+            "properties": {
+                "id": {
+                    "description": "Unique id used to reference a Sale",
+                    "type": "integer",
+                    "example": "1"
+                }
+            },
+            "type": "object",
+            "format": ""
+        }
+    },
+    "externalDocs": {
+        "description": "Find out more about Front Accounting Simple API",
+        "url": "http://swagger.io"
+    }
+}

--- a/swagger.json
+++ b/swagger.json
@@ -221,6 +221,163 @@
                 "deprecated": false
             }
         },
+        "/glaccounts": {
+            "get": {
+                "tags": [
+                    "glaccounts"
+                ],
+                "summary": "List all GL Accounts",
+                "operationId": "listGLAccounts",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GLAccount"
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            },
+            "post": {
+                "tags": [
+                    "glaccounts"
+                ],
+                "summary": "Add GL Account",
+                "operationId": "addGLAccount",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "description": "GL Account to be added",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/GLAccount"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "properties": {
+                                "account_code": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/glaccounts/{id}": {
+            "get": {
+                "tags": [
+                    "glaccounts"
+                ],
+                "summary": "Get GL Account by id",
+                "operationId": "getGLAccount",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "glAccountId",
+                        "in": "path",
+                        "description": "ID of GL Account to return",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/GLAccount"
+                        }
+                    }
+                },
+                "deprecated": false
+            },
+            "put": {
+                "tags": [
+                    "glaccounts"
+                ],
+                "summary": "Update GL Account",
+                "operationId": "updateGLAccount",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "dimensionId",
+                        "in": "path",
+                        "description": "ID of GL Account to update",
+                        "required": true,
+                        "type": "string"
+                    },
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "description": "GL Account to be updated",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/GLAccount"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "properties": {
+                                "account_code": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "deprecated": false
+            },
+            "delete": {
+                "tags": [
+                    "glaccounts"
+                ],
+                "summary": "Delete GL Account",
+                "operationId": "deleteGLAccount",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "glAccountId",
+                        "in": "path",
+                        "description": "ID of GL Account to delete",
+                        "required": true,
+                        "type": "string"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation"
+                    }
+                },
+                "deprecated": false
+            }
+        },
         "/sales": {
             "get": {
                 "tags": [
@@ -400,6 +557,38 @@
                     "description": "A longer memo",
                     "type": "string",
                     "example": "Some memo"
+                }
+            },
+            "type": "object",
+            "format": ""
+        },
+        "GLAccount": {
+            "description": "A GLAccount",
+            "properties": {
+                "account_code": {
+                    "description": "Unique short human readable id used to reference a GLAccount",
+                    "type": "string",
+                    "example": "1060"
+                },
+                "account_code2": {
+                    "description": "Secondary account code, may be blank",
+                    "type": "string",
+                    "example": ""
+                },
+                "account_name": {
+                    "description": "A longer name for the account",
+                    "type": "string",
+                    "example": "My Bank Savings Account"
+                },
+                "account_type": {
+                    "description": "Type of the account",
+                    "type": "string",
+                    "example": ""
+                },
+                "inactive": {
+                    "description": "Zero if account is active",
+                    "type": "int",
+                    "example": "0"
                 }
             },
             "type": "object",

--- a/swagger.json
+++ b/swagger.json
@@ -61,6 +61,166 @@
                 "deprecated": false
             }
         },
+        "/dimensions": {
+            "get": {
+                "tags": [
+                    "dimensions"
+                ],
+                "summary": "List all Dimensions",
+                "operationId": "listDimensions",
+                "produces": [
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Dimension"
+                            }
+                        }
+                    }
+                },
+                "deprecated": false
+            },
+            "post": {
+                "tags": [
+                    "dimensions"
+                ],
+                "summary": "Add Dimension",
+                "operationId": "addDimension",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "description": "Dimension to be added",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Dimension"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "schema": {
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "deprecated": false
+            }
+        },
+        "/dimensions/{id}": {
+            "get": {
+                "tags": [
+                    "dimensions"
+                ],
+                "summary": "Get Dimension by id",
+                "operationId": "getDimension",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "dimensionId",
+                        "in": "path",
+                        "description": "ID of Dimension to return",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "type": "object",
+                            "$ref": "#/definitions/Dimension"
+                        }
+                    }
+                },
+                "deprecated": false
+            },
+            "put": {
+                "tags": [
+                    "dimensions"
+                ],
+                "summary": "Update Dimension",
+                "operationId": "updateDimension",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "dimensionId",
+                        "in": "path",
+                        "description": "ID of Dimension to update",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    },
+                    {
+                        "name": "body",
+                        "in": "body",
+                        "description": "Dimension to be updated",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/Dimension"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "schema": {
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                }
+                            },
+                            "type": "object"
+                        }
+                    }
+                },
+                "deprecated": false
+            },
+            "delete": {
+                "tags": [
+                    "dimensions"
+                ],
+                "summary": "Delete Dimension",
+                "operationId": "deleteDimension",
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "dimensionId",
+                        "in": "path",
+                        "description": "ID of Dimension to delete",
+                        "required": true,
+                        "type": "integer",
+                        "format": "int64"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation"
+                    }
+                },
+                "deprecated": false
+            }
+        },
         "/sales": {
             "get": {
                 "tags": [
@@ -213,6 +373,33 @@
                     "description": "True if this account is not active",
                     "type": "boolean",
                     "example": "0"
+                }
+            },
+            "type": "object",
+            "format": ""
+        },
+        "Dimension": {
+            "description": "A Dimension",
+            "properties": {
+                "id": {
+                    "description": "Unique id used to reference a Dimension",
+                    "type": "integer",
+                    "example": "1"
+                },
+                "reference": {
+                    "description": "Unique short human readable reference",
+                    "type": "string",
+                    "example": "PROJECT1"
+                },
+                "name": {
+                    "description": "A longer human readable name",
+                    "type": "string",
+                    "example": "Project 1: Building buildings"
+                },
+                "memo": {
+                    "description": "A longer memo",
+                    "type": "string",
+                    "example": "Some memo"
                 }
             },
             "type": "object",

--- a/tests/BankAccounts_Test.php
+++ b/tests/BankAccounts_Test.php
@@ -1,77 +1,101 @@
 <?php
 use GuzzleHttp\Client;
 
-require_once (__DIR__ . '/TestConfig.php');
+require_once(__DIR__ . '/TestConfig.php');
 
-require_once (TEST_PATH . '/TestEnvironment.php');
+require_once(TEST_PATH . '/TestEnvironment.php');
+require_once(TEST_PATH . '/Crud_Base.php');
 
-class BankAccountsTest extends PHPUnit_Framework_TestCase
+const BANKACCOUNT_POST_DATA = array(
+    'account_code' => '123456',
+    'account_type' => '0',
+    'bank_account_name' => 'Bank Test Account',
+    'bank_account_number' => '12-3456-789123-00',
+    'bank_curr_code' => 'USD',
+    'bank_name' => 'Bank Test Name',
+    'bank_address' => 'Bank Test Address',
+    'bank_charge_act' => '5690',
+    'dflt_curr_act' => '0',
+    'inactive' => '0'
+);
+
+class BankAccountsTest extends Crud_Base
 {
+    private $postData = BANKACCOUNT_POST_DATA;
+    
+    private $putData;
+    
+    public function __construct()
+    {
+        $this->putData = $this->postData;
+        $this->putData['bank_account_name'] = 'Bank Test Account Edited';
 
-	public function testSale_CreateUpdateReadVoid_Ok()
-	{
-		$client = TestEnvironment::client();
-		$response = $client->get('/modules/api/bankaccounts/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        parent::__construct(
+            '/modules/api/bankaccounts/',
+            'id',
+            $this->postData,
+            $this->putData
+        );
+    }
 
-		$this->assertEquals(2, count($result));
+    protected function checkGetAfterPost($result)
+    {
+        $expected = $this->fixExpectedType($this->postData, $result);
+        $expected->last_reconciled_date = '0000-00-00 00:00:00';
+        $expected->ending_reconcile_balance = '0';
+        $result = $this->removeKeyProperty($result);
+        $this->assertEquals($expected, $result, 'Failed GET after POST');
+    }
 
-		$expected = array();
-		$expected[] = new stdClass();
-		$expected[0]->account_code = '1060';
-		$expected[0]->account_type = '0';
-		$expected[0]->id = '1';
-		$expected[0]->bank_account_name = 'Current account';
-		$expected[0]->bank_name = 'N/A';
-		$expected[0]->bank_account_number = 'N/A';
-		$expected[0]->bank_curr_code = 'USD';
-		$expected[0]->bank_address = '';
-		$expected[0]->dflt_curr_act = '1';
-		$expected[] = new stdClass();
-		$expected[1]->account_code = '1065';
-		$expected[1]->account_type = '3';
-		$expected[1]->id = '2';
-		$expected[1]->bank_account_name = 'Petty Cash account';
-		$expected[1]->bank_name = 'N/A';
-		$expected[1]->bank_account_number = 'N/A';
-		$expected[1]->bank_curr_code = 'USD';
-		$expected[1]->bank_address = '';
-		$expected[1]->dflt_curr_act = '0';
+    protected function checkGetAfterPut($result)
+    {
+        $expected = $this->fixExpectedType($this->putData, $result);
+        $result = $this->removeKeyProperty($result);
+        $expected->last_reconciled_date = '0000-00-00 00:00:00';
+        $expected->ending_reconcile_balance = '0';
+        $this->assertEquals($expected, $result, 'Failed GET after PUT');
+    }
 
-		$this->assertEquals($expected, $result);
-	}
+    // 	public function testCRUD_Ok();
+}
 
-	public function testAccountGetById_Ok()
-	{
-		$client = TestEnvironment::client();
-		$response = $client->get('/modules/api/bankaccounts/1', array(
-			'headers' => TestEnvironment::headers()
-		));
+class BankAccountsOtherTest extends PHPUnit_Framework_TestCase
+{
+    public function testBankAccount_ReadAll_Ok()
+    {
+        $client = TestEnvironment::client();
+        $response = $client->get('/modules/api/bankaccounts/', array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
+        $this->assertEquals(2, count($result));
 
-		$result = json_decode($result);
+        $expected = array();
+        $expected[] = new stdClass();
+        $expected[0]->account_code = '1060';
+        $expected[0]->account_type = '0';
+        $expected[0]->id = '1';
+        $expected[0]->bank_account_name = 'Current account';
+        $expected[0]->bank_name = 'N/A';
+        $expected[0]->bank_account_number = 'N/A';
+        $expected[0]->bank_curr_code = 'USD';
+        $expected[0]->bank_address = '';
+        $expected[0]->dflt_curr_act = '1';
+        $expected[] = new stdClass();
+        $expected[1]->account_code = '1065';
+        $expected[1]->account_type = '3';
+        $expected[1]->id = '2';
+        $expected[1]->bank_account_name = 'Petty Cash account';
+        $expected[1]->bank_name = 'N/A';
+        $expected[1]->bank_account_number = 'N/A';
+        $expected[1]->bank_curr_code = 'USD';
+        $expected[1]->bank_address = '';
+        $expected[1]->dflt_curr_act = '0';
 
-		$expected = new stdClass();
-		$expected->account_code = '1060';
-		$expected->account_type = '0';
-		$expected->id = '1';
-		$expected->bank_account_name = 'Current account';
-		$expected->bank_name = 'N/A';
-		$expected->bank_account_number = 'N/A';
-		$expected->bank_curr_code = 'USD';
-		$expected->bank_address = '';
-		$expected->dflt_curr_act = '1';
-		$expected->bank_charge_act = '5690';
-		$expected->last_reconciled_date = '0000-00-00 00:00:00';
-		$expected->ending_reconcile_balance = '0';
-		$expected->inactive = '0';
+        $this->assertEquals($expected, $result);
+    }
 
-		$this->assertEquals($expected, $result);
-	}
 }

--- a/tests/Category_Test.php
+++ b/tests/Category_Test.php
@@ -8,65 +8,63 @@ require_once(TEST_PATH . '/TestEnvironment.php');
 require_once(TEST_PATH . '/Crud_Base.php');
 
 const CATEGORY_DATA = array(
-	'description' => 'description',
-	'dflt_tax_type' => '1',
-	'dflt_units' => 'each',
-	'dflt_mb_flag' => 'D',
-	'dflt_sales_act' => '4010',
-	'dflt_cogs_act' => '5010',
-	'dflt_inventory_act' => '1510',
-	'dflt_adjustment_act' => '5040',
-	'dflt_wip_act' => '1530',
-	'dflt_dim1' => '0',
-	'dflt_dim2' => '0',
-	'inactive' => '0',
-	'dflt_no_sale' => '0',
-	'dflt_no_purchase' => '0',
+    'description' => 'description',
+    'dflt_tax_type' => '1',
+    'dflt_units' => 'each',
+    'dflt_mb_flag' => 'D',
+    'dflt_sales_act' => '4010',
+    'dflt_cogs_act' => '5010',
+    'dflt_inventory_act' => '1510',
+    'dflt_adjustment_act' => '5040',
+    'dflt_wip_act' => '1530',
+    'dflt_dim1' => '0',
+    'dflt_dim2' => '0',
+    'inactive' => '0',
+    'dflt_no_sale' => '0',
+    'dflt_no_purchase' => '0',
 );
 
 class CategoryTest extends Crud_Base
 {
-	private $postData = CATEGORY_DATA;
+    private $postData = CATEGORY_DATA;
 
-	private $putData;
+    private $putData;
 
-	public function __construct()
-	{
-		$this->putData = $this->postData;
-		$this->putData['description'] = 'other description';
+    public function __construct()
+    {
+        $this->putData = $this->postData;
+        $this->putData['description'] = 'other description';
 
-		parent::__construct(
-			'/modules/api/category/',
-			'category_id',
-			$this->postData,
-			$this->putData
-		);
-	}
+        parent::__construct(
+            '/modules/api/category/',
+            'category_id',
+            $this->postData,
+            $this->putData
+        );
+    }
 
-	// 	public function testCRUD_Ok();
-
+    // 	public function testCRUD_Ok();
 }
 
 class CategoryJsonTest extends Crud_Base
 {
-	private $postData = CATEGORY_DATA;
+    private $postData = CATEGORY_DATA;
 
-	private $putData;
+    private $putData;
 
-	public function __construct()
-	{
-		$this->putData = $this->postData;
-		$this->putData['description'] = 'other description';
+    public function __construct()
+    {
+        $this->putData = $this->postData;
+        $this->putData['description'] = 'other description';
 
-		parent::__construct(
-			'/modules/api/category/',
-			'category_id',
-			$this->postData,
-			$this->putData
-		);
-		$this->method = Crud_Base::JSON;
-	}
+        parent::__construct(
+            '/modules/api/category/',
+            'category_id',
+            $this->postData,
+            $this->putData
+        );
+        $this->method = Crud_Base::JSON;
+    }
 
-	// 	public function testCRUD_Ok();
-
+    // 	public function testCRUD_Ok();
 }

--- a/tests/Crud_Base.php
+++ b/tests/Crud_Base.php
@@ -144,8 +144,6 @@ abstract class Crud_Base extends PHPUnit_Framework_TestCase
 		$result = $this->getAll();
 		$count1 = count($result);
 		$this->assertEquals($count0 + 1, $count1);
-		// The id should be the same
-		$this->assertEquals($id, $result[$count1 - 1]->{$this->keyProperty});
 
 		// Get by id
 		$response = $client->get($this->url . $id, array(

--- a/tests/Crud_Base.php
+++ b/tests/Crud_Base.php
@@ -8,166 +8,163 @@ require_once(TEST_PATH . '/TestEnvironment.php');
 
 abstract class Crud_Base extends PHPUnit_Framework_TestCase
 {
-	private $postData;
+    private $postData;
 
-	private $putData;
+    private $putData;
 
-	private $url;
+    private $url;
 
-	private $keyProperty;
+    private $keyProperty;
 
-	protected $method;
+    protected $method;
 
-	const JSON = 'json';
-	const FORM_DATA = 'form_params';
+    const JSON = 'json';
+    const FORM_DATA = 'form_params';
 
-	/**
-	 * Constructor. The $putData will be set to $postData if not set
-	 * @param string $url url of the endpoint 
-	 * @param string $keyProperty the property containing the key id
-	 * @param array $postData example data to use in post (create)
-	 * @param array $putData example data to use in put (update)
-	 */
-	public function __construct($url, $keyProperty, $postData, $putData = null)
-	{
-		$this->url = $url;
-		$this->keyProperty = $keyProperty;
+    /**
+     * Constructor. The $putData will be set to $postData if not set
+     * @param string $url url of the endpoint
+     * @param string $keyProperty the property containing the key id
+     * @param array $postData example data to use in post (create)
+     * @param array $putData example data to use in put (update)
+     */
+    public function __construct($url, $keyProperty, $postData, $putData = null)
+    {
+        $this->url = $url;
+        $this->keyProperty = $keyProperty;
 
-		$this->postData = $postData;
-		$this->putData = $putData ? $putData : $postData;
+        $this->postData = $postData;
+        $this->putData = $putData ? $putData : $postData;
 
-		$this->method = Crud_Base::FORM_DATA;
-	}
+        $this->method = Crud_Base::FORM_DATA;
+    }
 
-	protected function checkCountInitial($count, $result)
-	{
-		// $this->assertGreaterThan(0, $count); // TODO Not sure about the one here.  zero should be ok
-	}
+    protected function checkCountInitial($count, $result)
+    {
+        // $this->assertGreaterThan(0, $count); // TODO Not sure about the one here.  zero should be ok
+    }
 
-	protected function fixExpectedType($expected, $result)
-	{
-		$expectedNew = null;
-		if (is_a($result, 'stdClass')) {
-			$expectedNew = new \stdClass();
-			foreach ($expected as $key => $value) {
-				$expectedNew->{$key} = $value;
-			}
-		} else {
-			$expectedNew = $this->postData;
-		}
-		return $expectedNew;
-	}
+    protected function fixExpectedType($expected, $result)
+    {
+        $expectedNew = null;
+        if (is_a($result, 'stdClass')) {
+            $expectedNew = new \stdClass();
+            foreach ($expected as $key => $value) {
+                $expectedNew->{$key} = $value;
+            }
+        } else {
+            $expectedNew = $this->postData;
+        }
+        return $expectedNew;
+    }
 
-	protected function removeKeyProperty($result)
-	{
-		if (isset($result->{$this->keyProperty}))
-		{
-			unset($result->{$this->keyProperty});
-		}
-		return $result;
-	}
+    protected function removeKeyProperty($result)
+    {
+        if (isset($result->{$this->keyProperty})) {
+            unset($result->{$this->keyProperty});
+        }
+        return $result;
+    }
 
-	protected function checkGetAfterPost($result)
-	{
-		$expected = $this->fixExpectedType($this->postData, $result);
-		$result = $this->removeKeyProperty($result);
-		$this->assertEquals($expected, $result, 'Failed GET after POST');
-	}
+    protected function checkGetAfterPost($result)
+    {
+        $expected = $this->fixExpectedType($this->postData, $result);
+        $result = $this->removeKeyProperty($result);
+        $this->assertEquals($expected, $result, 'Failed GET after POST');
+    }
 
-	protected function checkGetAfterPut($result)
-	{
-		$expected = $this->fixExpectedType($this->putData, $result);
-		$result = $this->removeKeyProperty($result);
-		$this->assertEquals($expected, $result, 'Failed GET after PUT');
-	}
+    protected function checkGetAfterPut($result)
+    {
+        $expected = $this->fixExpectedType($this->putData, $result);
+        $result = $this->removeKeyProperty($result);
+        $this->assertEquals($expected, $result, 'Failed GET after PUT');
+    }
 
-	protected function getAll()
-	{
-		$client = TestEnvironment::client();
-		$response = $client->get($this->url, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-		return $result;
-	}
+    protected function getAll()
+    {
+        $client = TestEnvironment::client();
+        $response = $client->get($this->url, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
+        return $result;
+    }
 
-	public function testCRUD_Ok()
-	{
-		$client = TestEnvironment::client();
+    public function testCRUD_Ok()
+    {
+        $client = TestEnvironment::client();
 
-		// List
-		$result = $this->getAll();
-		$count0 = count($result);
-		$this->checkCountInitial($count0, $result);
+        // List
+        $result = $this->getAll();
+        $count0 = count($result);
+        $this->checkCountInitial($count0, $result);
 
-		// Add
-		$response = $client->post($this->url, array(
-			'headers' => TestEnvironment::headers(),
-			$this->method => $this->postData
-		));
-		$this->assertEquals('201', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-		$id = $result->{$this->keyProperty};
+        // Add
+        $response = $client->post($this->url, array(
+            'headers' => TestEnvironment::headers(),
+            $this->method => $this->postData
+        ));
+        $this->assertEquals('201', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
+        $id = $result->{$this->keyProperty};
 
-		$this->assertNotNull($id);
+        $this->assertNotNull($id);
 
-		// List again
-		$result = $this->getAll();
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
+        // List again
+        $result = $this->getAll();
+        $count1 = count($result);
+        $this->assertEquals($count0 + 1, $count1);
 
-		// Get by id
-		$response = $client->get($this->url . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-		$this->assertEquals($id, $result->{$this->keyProperty});
-		$this->checkGetAfterPost($result);
+        // Get by id
+        $response = $client->get($this->url . $id, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
+        $this->assertEquals($id, $result->{$this->keyProperty});
+        $this->checkGetAfterPost($result);
 
-		// Write back
-		$response = $client->put($this->url . $id, array(
-			'headers' => TestEnvironment::headers(),
-			$this->method => $this->putData
-		));
+        // Write back
+        $response = $client->put($this->url . $id, array(
+            'headers' => TestEnvironment::headers(),
+            $this->method => $this->putData
+        ));
 
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		// List again
-		// Count should be the same, i.e. no increase
-		$result = $this->getAll();
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
+        // List again
+        // Count should be the same, i.e. no increase
+        $result = $this->getAll();
+        $count1 = count($result);
+        $this->assertEquals($count0 + 1, $count1);
 
-		// Get by id
-		$response = $client->get($this->url . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-		$this->assertEquals($id, $result->{$this->keyProperty});
-		$this->checkGetAfterPut($result);
+        // Get by id
+        $response = $client->get($this->url . $id, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
+        $this->assertEquals($id, $result->{$this->keyProperty});
+        $this->checkGetAfterPut($result);
 
-		// Delete
-		$response = $client->delete($this->url . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // Delete
+        $response = $client->delete($this->url . $id, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		// List again
-		$result = $this->getAll();
-		$count2 = count($result);
-		$this->assertEquals($count0, $count2);
-
-	}
-
+        // List again
+        $result = $this->getAll();
+        $count2 = count($result);
+        $this->assertEquals($count0, $count2);
+    }
 }

--- a/tests/Crud_Base.php
+++ b/tests/Crud_Base.php
@@ -12,8 +12,6 @@ abstract class Crud_Base extends PHPUnit_Framework_TestCase
 
 	private $putData;
 
-	private $getData;
-
 	private $url;
 
 	private $keyProperty;
@@ -24,21 +22,19 @@ abstract class Crud_Base extends PHPUnit_Framework_TestCase
 	const FORM_DATA = 'form_params';
 
 	/**
-	 * Constructor. The $putData and $getData will be set to $postData if not set
+	 * Constructor. The $putData will be set to $postData if not set
 	 * @param string $url url of the endpoint 
 	 * @param string $keyProperty the property containing the key id
 	 * @param array $postData example data to use in post (create)
 	 * @param array $putData example data to use in put (update)
-	 * @param array $getData example data to compare with in get (read)
 	 */
-	public function __construct($url, $keyProperty, $postData, $putData = null, $getData = null)
+	public function __construct($url, $keyProperty, $postData, $putData = null)
 	{
 		$this->url = $url;
 		$this->keyProperty = $keyProperty;
 
 		$this->postData = $postData;
 		$this->putData = $putData ? $putData : $postData;
-		$this->getData = $getData ? $getData : $postData;
 
 		$this->method = Crud_Base::FORM_DATA;
 	}

--- a/tests/Customer_Test.php
+++ b/tests/Customer_Test.php
@@ -8,68 +8,67 @@ require_once(TEST_PATH . '/TestEnvironment.php');
 require_once(TEST_PATH . '/Crud_Base.php');
 
 const CUSTOMER_POST_DATA = array(
-	'name' => 'custname',
-	'debtor_ref' => 'debtor_ref',
-	'address' => 'address',
-	'tax_id' => 'tax_id',
-	'curr_code' => 'USD',
-	'credit_status' => '1',
-	'payment_terms' => '1',
-	'discount' => '0',
-	'pymt_discount' => '0',
-	'credit_limit' => '1000',
-	'sales_type' => '1',
-	'notes' => 'notes',
-	'dimension_id' => '0',
-	'dimension2_id' => '0',
-	'inactive' => '0',
+    'name' => 'custname',
+    'debtor_ref' => 'debtor_ref',
+    'address' => 'address',
+    'tax_id' => 'tax_id',
+    'curr_code' => 'USD',
+    'credit_status' => '1',
+    'payment_terms' => '1',
+    'discount' => '0',
+    'pymt_discount' => '0',
+    'credit_limit' => '1000',
+    'sales_type' => '1',
+    'notes' => 'notes',
+    'dimension_id' => '0',
+    'dimension2_id' => '0',
+    'inactive' => '0',
 );
 
 const CUSTOMER_PUT_DATA = array(
-	'name' => 'new custname',
-	'debtor_ref' => 'new debtor_ref',
-	'address' => 'new address',
-	'tax_id' => 'new tax_id',
-	'curr_code' => 'NZD',
-	'credit_status' => '2',
-	'payment_terms' => '2',
-	'discount' => '1',
-	'pymt_discount' => '1',
-	'credit_limit' => '2000',
-	'sales_type' => '2',
-	'notes' => 'new notes',
-	'dimension_id' => '0',  // Not yet implemented
-	'dimension2_id' => '0', // Not yet implemented
-	'inactive' => '0',      // Not yet implemented
+    'name' => 'new custname',
+    'debtor_ref' => 'new debtor_ref',
+    'address' => 'new address',
+    'tax_id' => 'new tax_id',
+    'curr_code' => 'NZD',
+    'credit_status' => '2',
+    'payment_terms' => '2',
+    'discount' => '1',
+    'pymt_discount' => '1',
+    'credit_limit' => '2000',
+    'sales_type' => '2',
+    'notes' => 'new notes',
+    'dimension_id' => '0',  // Not yet implemented
+    'dimension2_id' => '0', // Not yet implemented
+    'inactive' => '0',      // Not yet implemented
 );
 
 class CustomerTest extends Crud_Base
 {
+    private $postData = CUSTOMER_POST_DATA;
+    
+    private $putData = CUSTOMER_PUT_DATA;
+    
+    public function __construct()
+    {
+        parent::__construct(
+            '/modules/api/customers/',
+            'debtor_no',
+            $this->postData,
+            $this->putData
+        );
+    }
 
-	private $postData = CUSTOMER_POST_DATA;
-	
-	private $putData = CUSTOMER_PUT_DATA;
-	
-	public function __construct()
-	{
-		parent::__construct(
-			'/modules/api/customers/',
-			'debtor_no',
-			$this->postData,
-			$this->putData
-		);
-	}
-
-	// 	public function testCRUD_Ok();
+    // 	public function testCRUD_Ok();
 }
 
 // class CustomerJsonTest extends Crud_Base
 // {
 
 // 	private $postData = CUSTOMER_POST_DATA;
-	
+    
 // 	private $putData = CUSTOMER_PUT_DATA;
-	
+    
 // 	public function __construct()
 // 	{
 // 		parent::__construct(

--- a/tests/Dimension_Test.php
+++ b/tests/Dimension_Test.php
@@ -1,0 +1,40 @@
+<?php
+
+use GuzzleHttp\Client;
+
+require_once(__DIR__ . '/TestConfig.php');
+
+require_once(TEST_PATH . '/TestEnvironment.php');
+require_once(TEST_PATH . '/Crud_Base.php');
+
+const DIMENSION_POST_DATA = array(
+	'reference' => 'DIM1',
+	'name' => 'Dimension 1',
+	'closed' => '0',
+	'type_' => '0',
+	'date_' => '0000-00-00',
+	'due_date' => '0000-00-00'
+);
+
+class DimensionTest extends Crud_Base
+{
+	private $postData = DIMENSION_POST_DATA;
+	
+	private $putData;
+	
+	public function __construct()
+	{
+		$this->putData = $this->postData;
+		$this->putData['name'] = 'Dimension 1 Edited';
+
+		parent::__construct(
+			'/modules/api/dimensions/',
+			'id',
+			$this->postData,
+			$this->putData
+		);
+	}
+
+	// 	public function testCRUD_Ok();
+
+}

--- a/tests/Dimension_Test.php
+++ b/tests/Dimension_Test.php
@@ -8,33 +8,32 @@ require_once(TEST_PATH . '/TestEnvironment.php');
 require_once(TEST_PATH . '/Crud_Base.php');
 
 const DIMENSION_POST_DATA = array(
-	'reference' => 'DIM1',
-	'name' => 'Dimension 1',
-	'closed' => '0',
-	'type_' => '0',
-	'date_' => '0000-00-00',
-	'due_date' => '0000-00-00'
+    'reference' => 'DIM1',
+    'name' => 'Dimension 1',
+    'closed' => '0',
+    'type_' => '0',
+    'date_' => '0000-00-00',
+    'due_date' => '0000-00-00'
 );
 
 class DimensionTest extends Crud_Base
 {
-	private $postData = DIMENSION_POST_DATA;
-	
-	private $putData;
-	
-	public function __construct()
-	{
-		$this->putData = $this->postData;
-		$this->putData['name'] = 'Dimension 1 Edited';
+    private $postData = DIMENSION_POST_DATA;
+    
+    private $putData;
+    
+    public function __construct()
+    {
+        $this->putData = $this->postData;
+        $this->putData['name'] = 'Dimension 1 Edited';
 
-		parent::__construct(
-			'/modules/api/dimensions/',
-			'id',
-			$this->postData,
-			$this->putData
-		);
-	}
+        parent::__construct(
+            '/modules/api/dimensions/',
+            'id',
+            $this->postData,
+            $this->putData
+        );
+    }
 
-	// 	public function testCRUD_Ok();
-
+    // 	public function testCRUD_Ok();
 }

--- a/tests/GLAccounts_Test.php
+++ b/tests/GLAccounts_Test.php
@@ -5,77 +5,70 @@ use GuzzleHttp\Client;
 require_once(__DIR__ . '/TestConfig.php');
 
 require_once(TEST_PATH . '/TestEnvironment.php');
-
 require_once(TEST_PATH . '/Crud_Base.php');
 
 const GL_POST_DATA = array(
-	'account_code' => '123456',
-	'account_code2' => '',
-	'account_name' => 'GL Test Account',
-	'account_type' => '1',
-	'inactive' => '0'
+    'account_code' => '123456',
+    'account_code2' => '',
+    'account_name' => 'GL Test Account',
+    'account_type' => '1',
+    'inactive' => '0'
 );
 
-/**
- * @group wip
- */
 class GLAccountsTest extends Crud_Base
 {
-	private $postData = GL_POST_DATA;
-	
-	private $putData;
-	
-	public function __construct()
-	{
-		$this->putData = $this->postData;
-		$this->putData['account_name'] = 'GL Test Account Edited';
+    private $postData = GL_POST_DATA;
+    
+    private $putData;
+    
+    public function __construct()
+    {
+        $this->putData = $this->postData;
+        $this->putData['account_name'] = 'GL Test Account Edited';
 
-		parent::__construct(
-			'/modules/api/glaccounts/',
-			'account_code',
-			$this->postData,
-			$this->putData
-		);
-	}
+        parent::__construct(
+            '/modules/api/glaccounts/',
+            'account_code',
+            $this->postData,
+            $this->putData
+        );
+    }
 
-	protected function checkGetAfterPost($result)
-	{
-		$expected = $this->fixExpectedType($this->postData, $result);
-		$this->assertEquals($expected, $result, 'Failed GET after POST');
-	}
+    protected function checkGetAfterPost($result)
+    {
+        $expected = $this->fixExpectedType($this->postData, $result);
+        $this->assertEquals($expected, $result, 'Failed GET after POST');
+    }
 
-	protected function checkGetAfterPut($result)
-	{
-		$expected = $this->fixExpectedType($this->putData, $result);
-		$this->assertEquals($expected, $result, 'Failed GET after PUT');
-	}
+    protected function checkGetAfterPut($result)
+    {
+        $expected = $this->fixExpectedType($this->putData, $result);
+        $this->assertEquals($expected, $result, 'Failed GET after PUT');
+    }
 
-	// 	public function testCRUD_Ok();
-
+    // 	public function testCRUD_Ok();
 }
 
 class GLOtherTest extends PHPUnit_Framework_TestCase
 {
+    public function testAccountTypes_Ok()
+    {
+        $client = TestEnvironment::client();
+        $response = $client->get('/modules/api/glaccounttypes', array(
+            'headers' => TestEnvironment::headers()
+        ));
 
-	public function testAccountTypes_Ok()
-	{
-		$client = TestEnvironment::client();
-		$response = $client->get('/modules/api/glaccounttypes', array(
-			'headers' => TestEnvironment::headers()
-		));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$count = count($result);
-		$this->assertTrue($count > 0, 'Count > 0');
-		$expected = new stdClass();
-		$expected->id = '1';
-		$expected->name = 'Current Assets';
-		$expected->class_id = '1';
-		$expected->parent = '';
-		$this->assertEquals($expected, $result[0]);
-	}
-
+        $count = count($result);
+        $this->assertTrue($count > 0, 'Count > 0');
+        $expected = new stdClass();
+        $expected->id = '1';
+        $expected->name = 'Current Assets';
+        $expected->class_id = '1';
+        $expected->parent = '';
+        $this->assertEquals($expected, $result[0]);
+    }
 }

--- a/tests/GLAccounts_Test.php
+++ b/tests/GLAccounts_Test.php
@@ -19,7 +19,7 @@ const GL_POST_DATA = array(
 /**
  * @group wip
  */
-class GLTest extends Crud_Base
+class GLAccountsTest extends Crud_Base
 {
 	private $postData = GL_POST_DATA;
 	

--- a/tests/GL_Test.php
+++ b/tests/GL_Test.php
@@ -6,57 +6,56 @@ require_once(__DIR__ . '/TestConfig.php');
 
 require_once(TEST_PATH . '/TestEnvironment.php');
 
-class GLTest extends PHPUnit_Framework_TestCase
+require_once(TEST_PATH . '/Crud_Base.php');
+
+const GL_POST_DATA = array(
+	'account_code' => '123456',
+	'account_code2' => '',
+	'account_name' => 'GL Test Account',
+	'account_type' => '1',
+	'inactive' => '0'
+);
+
+/**
+ * @group wip
+ */
+class GLTest extends Crud_Base
 {
-
-	public function testAccountList_Ok()
+	private $postData = GL_POST_DATA;
+	
+	private $putData;
+	
+	public function __construct()
 	{
-		$client = TestEnvironment::client();
-		$response = $client->get('/modules/api/glaccounts/', array(
-			'headers' => TestEnvironment::headers()
-		));
+		$this->putData = $this->postData;
+		$this->putData['account_name'] = 'GL Test Account Edited';
 
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$this->assertEquals(2, count($result));
-
-		$expected = array();
-		$expected[] = new stdClass();
-		$expected[0]->account_code = '1060';
-		$expected[0]->account_name = 'Checking Account';
-		$expected[0]->account_type = '1';
-		$expected[0]->account_code2 = '';
-		$expected[] = new stdClass();
-		$expected[1]->account_code = '1065';
-		$expected[1]->account_name = 'Petty Cash';
-		$expected[1]->account_type = '1';
-		$expected[1]->account_code2 = '';
-
-		$this->assertEquals($expected, $result);
+		parent::__construct(
+			'/modules/api/glaccounts/',
+			'account_code',
+			$this->postData,
+			$this->putData
+		);
 	}
 
-	public function testAccountGetById_Ok()
+	protected function checkGetAfterPost($result)
 	{
-		$client = TestEnvironment::client();
-		$response = $client->get('/modules/api/glaccounts/1060', array(
-			'headers' => TestEnvironment::headers()
-		));
-
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
-
-		$expected = new stdClass();
-		$expected->account_code = '1060';
-		$expected->account_code2 = '';
-		$expected->account_name = 'Checking Account';
-		$expected->account_type = '1';
-		$expected->inactive = '0';
-
-		$this->assertEquals($expected, $result);
+		$expected = $this->fixExpectedType($this->postData, $result);
+		$this->assertEquals($expected, $result, 'Failed GET after POST');
 	}
+
+	protected function checkGetAfterPut($result)
+	{
+		$expected = $this->fixExpectedType($this->putData, $result);
+		$this->assertEquals($expected, $result, 'Failed GET after PUT');
+	}
+
+	// 	public function testCRUD_Ok();
+
+}
+
+class GLOtherTest extends PHPUnit_Framework_TestCase
+{
 
 	public function testAccountTypes_Ok()
 	{

--- a/tests/Inventory_Test.php
+++ b/tests/Inventory_Test.php
@@ -8,220 +8,215 @@ require_once(TEST_PATH . '/TestEnvironment.php');
 require_once(TEST_PATH . '/Crud_Base.php');
 
 const INVENTORY_POST_DATA = array(
-	'description' => 'description',
-	'long_description' => 'long description',
-	'category_id' => '1',
-	'tax_type_id' => '1',
-	'units' => 'ea',
-	'mb_flag' => '0',
-	'sales_account' => '1',
-	'inventory_account' => '1',
-	'cogs_account' => '1',
-	'adjustment_account' => '1',
-	'wip_account' => '1'
+    'description' => 'description',
+    'long_description' => 'long description',
+    'category_id' => '1',
+    'tax_type_id' => '1',
+    'units' => 'ea',
+    'mb_flag' => '0',
+    'sales_account' => '1',
+    'inventory_account' => '1',
+    'cogs_account' => '1',
+    'adjustment_account' => '1',
+    'wip_account' => '1'
 );
 
 const INVENTORY_GET_DATA = array(
-	'description' => 'description',
-	'long_description' => 'long description',
-	'category_id' => '1',
-	'tax_type_id' => '1',
-	'units' => 'ea',
-	'mb_flag' => '0',
-	'sales_account' => '1',
-	'inventory_account' => '1',
-	'cogs_account' => '1',
-	'adjustment_account' => '1',
-	'wip_account' => '1',
-	'dimension_id' => '0',
-	'dimension2_id' => '0',
-	'purchase_cost' => '0',
-	'last_cost' => '0',
-	'material_cost' => '0',
-	'labour_cost' => '0',
-	'overhead_cost' => '0',
-	'inactive' => '0',
-	'no_sale' => '0',
-	'no_purchase' => '0',
-	'editable' => '1',
-	'depreciation_method' => 'D',
-	'depreciation_rate' => '100',
-	'depreciation_factor' => '1',
-	'depreciation_start' => '0000-00-00',
-	'depreciation_date' => '0000-00-00',
-	'fa_class_id' => '',
-	'tax_type_name' => 'Regular',
+    'description' => 'description',
+    'long_description' => 'long description',
+    'category_id' => '1',
+    'tax_type_id' => '1',
+    'units' => 'ea',
+    'mb_flag' => '0',
+    'sales_account' => '1',
+    'inventory_account' => '1',
+    'cogs_account' => '1',
+    'adjustment_account' => '1',
+    'wip_account' => '1',
+    'dimension_id' => '0',
+    'dimension2_id' => '0',
+    'purchase_cost' => '0',
+    'last_cost' => '0',
+    'material_cost' => '0',
+    'labour_cost' => '0',
+    'overhead_cost' => '0',
+    'inactive' => '0',
+    'no_sale' => '0',
+    'no_purchase' => '0',
+    'editable' => '1',
+    'depreciation_method' => 'D',
+    'depreciation_rate' => '100',
+    'depreciation_factor' => '1',
+    'depreciation_start' => '0000-00-00',
+    'depreciation_date' => '0000-00-00',
+    'fa_class_id' => '',
+    'tax_type_name' => 'Regular',
 );
 
 class InventoryTest extends Crud_Base
 {
+    private $postData = INVENTORY_POST_DATA;
+    
+    private $putData;
+    
+    public function __construct()
+    {
+        // Note: The primary key needs to be provided by the client.
+        // It is not an auto-increment property.
+        $this->postData['stock_id'] = TestEnvironment::createId();
+        $this->putData = $this->postData;
+        $this->putData['description'] = 'new description';
+        $this->putData['long_description'] = 'new long description';
 
-	private $postData = INVENTORY_POST_DATA;
-	
-	private $putData;
-	
-	public function __construct()
-	{
-		// Note: The primary key needs to be provided by the client.
-		// It is not an auto-increment property.
-		$this->postData['stock_id'] = TestEnvironment::createId();
-		$this->putData = $this->postData;
-		$this->putData['description'] = 'new description';
-		$this->putData['long_description'] = 'new long description';
+        parent::__construct(
+            '/modules/api/inventory/',
+            'stock_id',
+            $this->postData,
+            $this->putData,
+            INVENTORY_GET_DATA
+        );
+    }
 
-		parent::__construct(
-			'/modules/api/inventory/',
-			'stock_id',
-			$this->postData,
-			$this->putData,
-			INVENTORY_GET_DATA
-		);
-	}
+    protected function checkGetAfterPost($result)
+    {
+        $expected = INVENTORY_GET_DATA;
+        $expected['stock_id'] = $this->postData['stock_id'];
+        $expected = $this->fixExpectedType($expected, $result);
+        // $result = $this->removeKeyProperty($result);
+        $this->assertEquals($expected, $result, 'Failed GET after POST');
+    }
 
-	protected function checkGetAfterPost($result)
-	{
-		$expected = INVENTORY_GET_DATA;
-		$expected['stock_id'] = $this->postData['stock_id'];
-		$expected = $this->fixExpectedType($expected, $result);
-		// $result = $this->removeKeyProperty($result);
-		$this->assertEquals($expected, $result, 'Failed GET after POST');
-	}
+    protected function checkGetAfterPut($result)
+    {
+        $expected = INVENTORY_GET_DATA;
+        $expected['stock_id'] = $this->putData['stock_id'];
+        // Update the expected with the modifications that we PUT
+        foreach ($this->putData as $key => $value) {
+            if (isset($expected[$key])) {
+                $expected[$key] = $value;
+            }
+        }
+        $expected = $this->fixExpectedType($expected, $result);
+        // $result = $this->removeKeyProperty($result);
+        $this->assertEquals($expected, $result, 'Failed GET after PUT');
+    }
 
-	protected function checkGetAfterPut($result)
-	{
-		$expected = INVENTORY_GET_DATA;
-		$expected['stock_id'] = $this->putData['stock_id'];
-		// Update the expected with the modifications that we PUT
-		foreach ($this->putData as $key => $value) {
-			if (isset($expected[$key])) {
-				$expected[$key] = $value;
-			}
-		}
-		$expected = $this->fixExpectedType($expected, $result);
-		// $result = $this->removeKeyProperty($result);
-		$this->assertEquals($expected, $result, 'Failed GET after PUT');
-	}
-
-	// 	public function testCRUD_Ok();
-
-
+    // 	public function testCRUD_Ok();
 }
 
 class InventoryOtherTest extends PHPUnit_Framework_TestCase
 {
-	public function testLocations_Ok()
-	{
-		$client = TestEnvironment::client();
+    public function testLocations_Ok()
+    {
+        $client = TestEnvironment::client();
 
-		// List
-		$response = $client->get('/modules/api/locations/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // List
+        $response = $client->get('/modules/api/locations/', array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$count0 = count($result);
+        $count0 = count($result);
 
-		// Add
-		$id = 'LOC';
-		$response = $client->post('/modules/api/locations/', array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'loc_code' => $id,
-				'location_name' => 'Location Name'
-			)
-		));
-		$this->assertEquals('201', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // Add
+        $id = 'LOC';
+        $response = $client->post('/modules/api/locations/', array(
+            'headers' => TestEnvironment::headers(),
+            'form_params' => array(
+                'loc_code' => $id,
+                'location_name' => 'Location Name'
+            )
+        ));
+        $this->assertEquals('201', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$this->assertEquals($id, $result->loc_code);
-		$this->assertEquals('Location Name', $result->location_name);
+        $this->assertEquals($id, $result->loc_code);
+        $this->assertEquals('Location Name', $result->location_name);
 
-		// List again
-		$response = $client->get('/modules/api/locations/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // List again
+        $response = $client->get('/modules/api/locations/', array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
-	}
+        $count1 = count($result);
+        $this->assertEquals($count0 + 1, $count1);
+    }
 
-	public function testItemCosts_Ok()
-	{
-		$client = TestEnvironment::client();
+    public function testItemCosts_Ok()
+    {
+        $client = TestEnvironment::client();
 
-		// Add
-		$id = TestEnvironment::createId();
-		$response = $client->post('/modules/api/inventory/', array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'stock_id' => $id,
-				'description' => 'description',
-				'long_description' => 'long description',
-				'category_id' => '1',
-				'tax_type_id' => '1',
-				'units' => 'ea',
-				'mb_flag' => '0',
-				'sales_account' => '1',
-				'inventory_account' => '1',
-				'cogs_account' => '1',
-				'adjustment_account' => '1',
-				'wip_account' => '1'
-			)
-		));
-		$this->assertEquals('201', $response->getStatusCode());
+        // Add
+        $id = TestEnvironment::createId();
+        $response = $client->post('/modules/api/inventory/', array(
+            'headers' => TestEnvironment::headers(),
+            'form_params' => array(
+                'stock_id' => $id,
+                'description' => 'description',
+                'long_description' => 'long description',
+                'category_id' => '1',
+                'tax_type_id' => '1',
+                'units' => 'ea',
+                'mb_flag' => '0',
+                'sales_account' => '1',
+                'inventory_account' => '1',
+                'cogs_account' => '1',
+                'adjustment_account' => '1',
+                'wip_account' => '1'
+            )
+        ));
+        $this->assertEquals('201', $response->getStatusCode());
 
-		// Read Item Cost
-		$response = $client->get('/modules/api/itemcosts/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // Read Item Cost
+        $response = $client->get('/modules/api/itemcosts/' . $id, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$expected = new stdClass();
-		$expected->stock_id = $id;
-		$expected->unit_cost = '0';
+        $expected = new stdClass();
+        $expected->stock_id = $id;
+        $expected->unit_cost = '0';
 
-		$this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $result);
 
-		// Write Item Cost
-		$response = $client->put('/modules/api/itemcosts/' . $id, array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'material_cost' => '1',
-				'labour_cost' => '2',
-				'overhead_cost' => '3'
-			)
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // Write Item Cost
+        $response = $client->put('/modules/api/itemcosts/' . $id, array(
+            'headers' => TestEnvironment::headers(),
+            'form_params' => array(
+                'material_cost' => '1',
+                'labour_cost' => '2',
+                'overhead_cost' => '3'
+            )
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$expected = new stdClass();
-		$expected->stock_id = $id;
+        $expected = new stdClass();
+        $expected->stock_id = $id;
 
-		$this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $result);
 
-		// Read Item Cost again
-		$response = $client->get('/modules/api/itemcosts/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // Read Item Cost again
+        $response = $client->get('/modules/api/itemcosts/' . $id, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$expected = new stdClass();
-		$expected->stock_id = $id;
-		$expected->unit_cost = '1';
+        $expected = new stdClass();
+        $expected->stock_id = $id;
+        $expected->unit_cost = '1';
 
-		$this->assertEquals($expected, $result);
-
-	}
-
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/Sales_Test.php
+++ b/tests/Sales_Test.php
@@ -11,147 +11,146 @@ require_once(SRC_PATH . '/includes/types.inc');
 
 class SalesTest extends PHPUnit_Framework_TestCase
 {
+    public function testCRUD_Ok()
+    {
+        $client = TestEnvironment::client();
 
-	public function testCRUD_Ok()
-	{
-		$client = TestEnvironment::client();
+        TestEnvironment::createCustomer($client, 'TEST_CUST', 'Test Customer');
+        TestEnvironment::createItem($client, 'TEST_ITEM', 'Test Item');
 
-		TestEnvironment::createCustomer($client, 'TEST_CUST', 'Test Customer');
-		TestEnvironment::createItem($client, 'TEST_ITEM', 'Test Item');
+        // List
+        $response = $client->get('/modules/api/sales/' . ST_SALESINVOICE, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		// List
-		$response = $client->get('/modules/api/sales/' . ST_SALESINVOICE, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        $count0 = count($result);
+        $this->assertEquals(0, $count0);
 
-		$count0 = count($result);
-		$this->assertEquals(0, $count0);
+        // Add
+        $ref = TestEnvironment::createId();
+        //?XDEBUG_SESSION_START=cambell
+        $response = $client->post('/modules/api/sales/', array(
+            'headers' => TestEnvironment::headers(),
+            'form_params' => array(
+                'trans_type' => ST_SALESINVOICE,
+                'ref' => $ref, // TODO Ideally the api would default this and return.
+                'comments' => 'comments',
+                'order_date' => '01/02/2013',
 
-		// Add
-		$ref = TestEnvironment::createId();
-		//?XDEBUG_SESSION_START=cambell
-		$response = $client->post('/modules/api/sales/', array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'trans_type' => ST_SALESINVOICE,
-				'ref' => $ref, // TODO Ideally the api would default this and return.
-				'comments' => 'comments',
-				'order_date' => '01/02/2013',
+                'delivery_date' => '03/04/2013',
+                'cust_ref' => 'cust_ref',
+                'deliver_to' => 'deliver_to',
+                'delivery_address' => 'delivery_address',
+                'phone' => 'phone',
+                'ship_via' => 'ship_via',
+                'location' => 'DEF',
+                'freight_cost' => '0',
+                'customer_id' => '2',
+                'branch_id' => '2',
+                'sales_type' => '1',
+                'dimension_id' => '0',
+                'dimension2_id' => '0',
 
-				'delivery_date' => '03/04/2013',
-				'cust_ref' => 'cust_ref',
-				'deliver_to' => 'deliver_to',
-				'delivery_address' => 'delivery_address',
-				'phone' => 'phone',
-				'ship_via' => 'ship_via',
-				'location' => 'DEF',
-				'freight_cost' => '0',
-				'customer_id' => '2',
-				'branch_id' => '2',
-				'sales_type' => '1',
-				'dimension_id' => '0',
-				'dimension2_id' => '0',
+                'items' => array(
+                    0 => array(
+                        'stock_id' => 'TEST_ITEM',
+                        'qty' => '1',
+                        'price' => '2',
+                        'discount' => '0',
+                        'description' => 'description'
+                    )
+                ),
+            )
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-				'items' => array(
-					0 => array(
-						'stock_id' => 'TEST_ITEM',
-						'qty' => '1',
-						'price' => '2',
-						'discount' => '0',
-						'description' => 'description'
-					)
-				),
-			)
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // List again
+        $response = $client->get('/modules/api/sales/' . ST_SALESINVOICE .'/', array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		// List again
-		$response = $client->get('/modules/api/sales/' . ST_SALESINVOICE .'/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // Regression test for https://github.com/andresamayadiaz/FrontAccountingSimpleAPI/issues/32
+        $this->assertEquals('0', $result[0]->ov_discount);
+        $this->assertEquals('2', $result[0]->Total);
 
-		// Regression test for https://github.com/andresamayadiaz/FrontAccountingSimpleAPI/issues/32
-		$this->assertEquals('0', $result[0]->ov_discount);
-		$this->assertEquals('2', $result[0]->Total);
+        $count1 = count($result);
+        $this->assertEquals($count0 + 1, $count1);
 
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
+        $id = $result[0]->trans_no;
 
-		$id = $result[0]->trans_no;
+        // Get by id
+        $response = $client->get('/modules/api/sales/' . $id . '/' . ST_SALESINVOICE, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		// Get by id
-		$response = $client->get('/modules/api/sales/' . $id . '/' . ST_SALESINVOICE, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        $expected = new stdClass();
+        $expected->ref = $ref;
+        $expected->comments = "comments";
+        $expected->order_date = "01/02/2013";
+        $expected->payment = "0";
+        $expected->payment_terms = false;
+        $expected->due_date =  "03/04/2013";
+        $expected->phone = "";
+        $expected->cust_ref = "cust_ref";
+        $expected->delivery_address = "delivery_address";
+        $expected->ship_via = "0";
+        $expected->deliver_to = "Test Customer";
+        $expected->delivery_date = "03/04/2013";
+        $expected->location = null;
+        $expected->freight_cost = "0";
+        $expected->email = "";
+        $expected->customer_id = "2";
+        $expected->branch_id = "2";
+        $expected->sales_type = "1";
+        $expected->dimension_id = "0";
+        $expected->dimension2_id = "0";
+        $item = new stdClass();
+        $item->id = "2";
+        $item->stock_id = "TEST_ITEM";
+        $item->qty = 1;
+        $item->units = "ea";
+        $item->price = "2";
+        $item->discount = "0";
+        $item->description = "description";
+        $expected->line_items = array($item);
+        $expected->sub_total = 2;
+        $expected->display_total = 2;
 
-		$expected = new stdClass();
-		$expected->ref = $ref;
-		$expected->comments = "comments";
-		$expected->order_date = "01/02/2013";
-		$expected->payment = "0";
-		$expected->payment_terms = false;
-		$expected->due_date =  "03/04/2013";
-		$expected->phone = "";
-		$expected->cust_ref = "cust_ref";
-		$expected->delivery_address = "delivery_address";
-		$expected->ship_via = "0";
-		$expected->deliver_to = "Test Customer";
-		$expected->delivery_date = "03/04/2013";
-		$expected->location = NULL;
-		$expected->freight_cost = "0";
-		$expected->email = "";
-		$expected->customer_id = "2";
-		$expected->branch_id = "2";
-		$expected->sales_type = "1";
-		$expected->dimension_id = "0";
-		$expected->dimension2_id = "0";
-		$item = new stdClass();
-		$item->id = "2";
-		$item->stock_id = "TEST_ITEM";
-		$item->qty = 1;
-		$item->units = "ea";
-		$item->price = "2";
-		$item->discount = "0";
-		$item->description = "description";
-		$expected->line_items = array($item);
-		$expected->sub_total = 2;
-		$expected->display_total = 2;
+        $this->assertEquals($expected, $result);
 
-		$this->assertEquals($expected, $result);
+        // Write back
+        $response = $client->put('/modules/api/sales/' . $id . '/' . ST_SALESINVOICE, array(
+            'headers' => TestEnvironment::headers(),
+            'form_params' => array(
+                'trans_type' => ST_SALESINVOICE,
+                'ref' => $ref, // TODO Ideally the api would default this and return.
+                'comments' => 'new comments',
+                'order_date' => '02/03/2013',
 
-		// Write back
-		$response = $client->put('/modules/api/sales/' . $id . '/' . ST_SALESINVOICE, array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'trans_type' => ST_SALESINVOICE,
-				'ref' => $ref, // TODO Ideally the api would default this and return.
-				'comments' => 'new comments',
-				'order_date' => '02/03/2013',
-
-				'delivery_date' => '04/05/2013',
-				'cust_ref' => 'cust_ref',
-				'deliver_to' => 'new deliver_to',
-				'delivery_address' => 'new delivery_address',
-				'phone' => 'new phone',
-				'ship_via' => 'new ship_via',
-				'location' => 'DEF',
-				'freight_cost' => '0',
-				'customer_id' => '2',
-				'branch_id' => '2',
-				'sales_type' => '1',
-				'dimension_id' => '0',
-				'dimension2_id' => '0',
+                'delivery_date' => '04/05/2013',
+                'cust_ref' => 'cust_ref',
+                'deliver_to' => 'new deliver_to',
+                'delivery_address' => 'new delivery_address',
+                'phone' => 'new phone',
+                'ship_via' => 'new ship_via',
+                'location' => 'DEF',
+                'freight_cost' => '0',
+                'customer_id' => '2',
+                'branch_id' => '2',
+                'sales_type' => '1',
+                'dimension_id' => '0',
+                'dimension2_id' => '0',
 
 // 				'items' => array(
 // 					0 => array(
@@ -162,78 +161,76 @@ class SalesTest extends PHPUnit_Framework_TestCase
 // 						'description' => 'new description'
 // 					)
 // 				),
-			)
-		));
+            )
+        ));
 
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		// Get by id
-		$response = $client->get('/modules/api/sales/' . $id . '/' . ST_SALESINVOICE, array(
-		    'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // Get by id
+        $response = $client->get('/modules/api/sales/' . $id . '/' . ST_SALESINVOICE, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$expected = new stdClass();
-		$expected->ref = $ref;
-		$expected->comments = "new comments";
-		$expected->order_date = "02/03/2013";
-		$expected->payment = "0";
-		$expected->payment_terms = false;
-		$expected->due_date =  "04/05/2013";
-		$expected->phone = "";
-		$expected->cust_ref = "cust_ref";
-		$expected->delivery_address = "delivery_address";
-		$expected->ship_via = "0";
-		$expected->deliver_to = "Test Customer";
-		$expected->delivery_date = "04/05/2013";
-		$expected->location = NULL;
-		$expected->freight_cost = "0";
-		$expected->email = "";
-		$expected->customer_id = "2";
-		$expected->branch_id = "2";
-		$expected->sales_type = "1";
-		$expected->dimension_id = "0";
-		$expected->dimension2_id = "0";
-		$item = new stdClass();
-		$item->id = "2";
-		$item->stock_id = "TEST_ITEM";
-		$item->qty = 1;
-		$item->units = "ea";
-		$item->price = "2";
-		$item->discount = "0";
-		$item->description = "description";
-		$expected->line_items = array($item);
-		$expected->sub_total = 2;
-		$expected->display_total = 2;
+        $expected = new stdClass();
+        $expected->ref = $ref;
+        $expected->comments = "new comments";
+        $expected->order_date = "02/03/2013";
+        $expected->payment = "0";
+        $expected->payment_terms = false;
+        $expected->due_date =  "04/05/2013";
+        $expected->phone = "";
+        $expected->cust_ref = "cust_ref";
+        $expected->delivery_address = "delivery_address";
+        $expected->ship_via = "0";
+        $expected->deliver_to = "Test Customer";
+        $expected->delivery_date = "04/05/2013";
+        $expected->location = null;
+        $expected->freight_cost = "0";
+        $expected->email = "";
+        $expected->customer_id = "2";
+        $expected->branch_id = "2";
+        $expected->sales_type = "1";
+        $expected->dimension_id = "0";
+        $expected->dimension2_id = "0";
+        $item = new stdClass();
+        $item->id = "2";
+        $item->stock_id = "TEST_ITEM";
+        $item->qty = 1;
+        $item->units = "ea";
+        $item->price = "2";
+        $item->discount = "0";
+        $item->description = "description";
+        $expected->line_items = array($item);
+        $expected->sub_total = 2;
+        $expected->display_total = 2;
 
-		$this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $result);
 
-		/* Delete is currently untested, and not implemented with standard FA
-		// Delete
-		$response = $client->delete('/modules/api/sales/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        /* Delete is currently untested, and not implemented with standard FA
+        // Delete
+        $response = $client->delete('/modules/api/sales/' . $id, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		// List again
-		$response = $client->get('/modules/api/sales/', array(
-			'headers' => TestEnvironment::headers()
-		));
+        // List again
+        $response = $client->get('/modules/api/sales/', array(
+            'headers' => TestEnvironment::headers()
+        ));
 
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$count2 = count($result);
-		$this->assertEquals($count0, $count2);
-		*/
-
-	}
-
+        $count2 = count($result);
+        $this->assertEquals($count0, $count2);
+        */
+    }
 }

--- a/tests/StockAdjust_Test.php
+++ b/tests/StockAdjust_Test.php
@@ -8,34 +8,32 @@ require_once(TEST_PATH . '/TestEnvironment.php');
 // require_once(TEST_PATH . '/Crud_Base.php');
 
 const STOCK_POST_DATA = array(
-	'stock_id' => 'TEST_ITEM',
-	'location' => 'DEF',
-	'date' => '1/2/2013',
-	'reference' => '1',
-	'quantity' => '1',
-	'standard_cost' => '0',
-	'memo' => 'Some Memo'
+    'stock_id' => 'TEST_ITEM',
+    'location' => 'DEF',
+    'date' => '1/2/2013',
+    'reference' => '1',
+    'quantity' => '1',
+    'standard_cost' => '0',
+    'memo' => 'Some Memo'
 );
 
 class StockAdjustTest extends PHPUnit_Framework_TestCase
 {
-	public function testStockAdjust_Ok()
-	{
-		$client = TestEnvironment::client();
+    public function testStockAdjust_Ok()
+    {
+        $client = TestEnvironment::client();
 
         // Adjust
-		$response = $client->post('/modules/api/stock/', array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => STOCK_POST_DATA
-		));
-		$this->assertEquals('201', $response->getStatusCode());
-		$result = $response->getBody();
+        $response = $client->post('/modules/api/stock/', array(
+            'headers' => TestEnvironment::headers(),
+            'form_params' => STOCK_POST_DATA
+        ));
+        $this->assertEquals('201', $response->getStatusCode());
+        $result = $response->getBody();
         $result = json_decode($result);
 
-		$this->assertEquals("Stock Adjustment has been added", $result->msg);
+        $this->assertEquals("Stock Adjustment has been added", $result->msg);
         
         // TODO Not sure if there is an API to verify the stock adjust, possibly inventory CP 2018-06
-
-	}
-
+    }
 }

--- a/tests/Supplier_Test.php
+++ b/tests/Supplier_Test.php
@@ -8,304 +8,303 @@ require_once(TEST_PATH . '/TestEnvironment.php');
 require_once(TEST_PATH . '/Crud_Base.php');
 
 const SUPPLIER_POST_DATA = array(
-	'supp_name' => 'supp_name',
-	'supp_ref' => 'supp_ref',
-	'address' => 'address',
-	'supp_address' => 'supp_address',
-	'gst_no' => 'gst_no',
-	'website' => 'website',
-	'supp_account_no' => 'supp_account_no',
-	'bank_account' => 'bank_account',
-	'credit_limit' => '1000',
-	'curr_code' => 'USD',
-	'payment_terms' => '1',
-	'payable_account' => '1010',
-	'purchase_account' => '1020',
-	'payment_discount_account' => '1030',
-	'notes' => 'notes',
-	'tax_group_id' => '1',
-	'tax_included' => '1',
-	'contact' => '',        // Not yet implemented
-	'dimension_id' => '0',  // Not yet implemented
-	'dimension2_id' => '0', // Not yet implemented
-	'inactive' => '0',      // Not yet implemented
+    'supp_name' => 'supp_name',
+    'supp_ref' => 'supp_ref',
+    'address' => 'address',
+    'supp_address' => 'supp_address',
+    'gst_no' => 'gst_no',
+    'website' => 'website',
+    'supp_account_no' => 'supp_account_no',
+    'bank_account' => 'bank_account',
+    'credit_limit' => '1000',
+    'curr_code' => 'USD',
+    'payment_terms' => '1',
+    'payable_account' => '1010',
+    'purchase_account' => '1020',
+    'payment_discount_account' => '1030',
+    'notes' => 'notes',
+    'tax_group_id' => '1',
+    'tax_included' => '1',
+    'contact' => '',        // Not yet implemented
+    'dimension_id' => '0',  // Not yet implemented
+    'dimension2_id' => '0', // Not yet implemented
+    'inactive' => '0',      // Not yet implemented
 );
 
 const SUPPLIER_PUT_DATA = array(
-	'supp_name' => 'new supp_name',
-	'supp_ref' => 'new supp_ref',
-	'address' => 'new address',
-	'supp_address' => 'new supp_address',
-	'gst_no' => 'new gst_no',
-	'website' => 'new website',
-	'supp_account_no' => 'new supp_account_no',
-	'bank_account' => 'new bank_account',
-	'credit_limit' => '2000',
-	'curr_code' => 'NZD',
-	'payment_terms' => '2',
-	'payable_account' => '2010',
-	'purchase_account' => '2020',
-	'payment_discount_account' => '2030',
-	'notes' => 'new notes',
-	'tax_group_id' => '2',
-	'tax_included' => '2',
-	'contact' => '',        // Not yet implemented
-	'dimension_id' => '0',  // Not yet implemented
-	'dimension2_id' => '0', // Not yet implemented
-	'inactive' => '0',      // Not yet implemented
+    'supp_name' => 'new supp_name',
+    'supp_ref' => 'new supp_ref',
+    'address' => 'new address',
+    'supp_address' => 'new supp_address',
+    'gst_no' => 'new gst_no',
+    'website' => 'new website',
+    'supp_account_no' => 'new supp_account_no',
+    'bank_account' => 'new bank_account',
+    'credit_limit' => '2000',
+    'curr_code' => 'NZD',
+    'payment_terms' => '2',
+    'payable_account' => '2010',
+    'purchase_account' => '2020',
+    'payment_discount_account' => '2030',
+    'notes' => 'new notes',
+    'tax_group_id' => '2',
+    'tax_included' => '2',
+    'contact' => '',        // Not yet implemented
+    'dimension_id' => '0',  // Not yet implemented
+    'dimension2_id' => '0', // Not yet implemented
+    'inactive' => '0',      // Not yet implemented
 );
 
 class SupplierTest extends Crud_Base
 {
+    private $postData = SUPPLIER_POST_DATA;
+    
+    private $putData = SUPPLIER_PUT_DATA;
+    
+    public function __construct()
+    {
+        parent::__construct(
+            '/modules/api/suppliers/',
+            'supplier_id',
+            $this->postData,
+            $this->putData
+        );
+    }
 
-	private $postData = SUPPLIER_POST_DATA;
-	
-	private $putData = SUPPLIER_PUT_DATA;
-	
-	public function __construct()
-	{
-		parent::__construct(
-			'/modules/api/suppliers/',
-			'supplier_id',
-			$this->postData,
-			$this->putData
-		);
-	}
+    // 	public function testCRUD_Ok();
+/*
+    public function testCRUD_Ok()
+    {
+        $client = TestEnvironment::client();
 
-	// 	public function testCRUD_Ok();
-/*	
-	public function testCRUD_Ok()
-	{
-		$client = TestEnvironment::client();
+        // List
+        $response = $client->get('/modules/api/suppliers/', array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		// List
-		$response = $client->get('/modules/api/suppliers/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        $count0 = count($result);
+        $this->assertEquals(0, $count0);
 
-		$count0 = count($result);
-		$this->assertEquals(0, $count0);
-
-		// Add
+        // Add
 // 		$id = TestEnvironment::createId();
-		$response = $client->post('/modules/api/suppliers/', array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'supp_name' => 'supp_name',
-				'supp_ref' => 'supp_ref',
-				'address' => 'address',
-				'supp_address' => 'supp_address',
-				'gst_no' => 'gst_no',
-				'website' => 'website',
-				'supp_account_no' => 'supp_account_no',
-				'bank_account' => 'bank_account',
-				'credit_limit' => '1000',
-				'curr_code' => 'USD',
-				'payment_terms' => '1',
-				'payable_account' => '1010',
-				'purchase_account' => '1020',
-				'payment_discount_account' => '1030',
-				'notes' => 'notes',
-				'tax_group_id' => '1',
-				'tax_included' => '1'
-			)
-		));
-		$this->assertEquals('201', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        $response = $client->post('/modules/api/suppliers/', array(
+            'headers' => TestEnvironment::headers(),
+            'form_params' => array(
+                'supp_name' => 'supp_name',
+                'supp_ref' => 'supp_ref',
+                'address' => 'address',
+                'supp_address' => 'supp_address',
+                'gst_no' => 'gst_no',
+                'website' => 'website',
+                'supp_account_no' => 'supp_account_no',
+                'bank_account' => 'bank_account',
+                'credit_limit' => '1000',
+                'curr_code' => 'USD',
+                'payment_terms' => '1',
+                'payable_account' => '1010',
+                'purchase_account' => '1020',
+                'payment_discount_account' => '1030',
+                'notes' => 'notes',
+                'tax_group_id' => '1',
+                'tax_included' => '1'
+            )
+        ));
+        $this->assertEquals('201', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
 // 		var_dump($result);
-		$id = $result->supplier_id;
+        $id = $result->supplier_id;
 
-		$expected = new stdClass();
-		$expected->supplier_id = '1';
-		$expected->supp_name = 'supp_name';
-		$expected->supp_ref = 'supp_ref';
-		$expected->address = 'address';
-		$expected->supp_address = 'supp_address';
-		$expected->gst_no = 'gst_no';
-		$expected->website = 'website';
-		$expected->supp_account_no = 'supp_account_no';
-		$expected->bank_account = 'bank_account';
-		$expected->credit_limit = '1000';
-		$expected->curr_code = 'USD';
-		$expected->payment_terms = '1';
-		$expected->payable_account = '1010';
-		$expected->purchase_account = '1020';
-		$expected->payment_discount_account = '1030';
-		$expected->notes = 'notes';
-		$expected->tax_group_id = '1';
-		$expected->tax_included = '1';
-		$expected->contact = '';
-		$expected->dimension_id = '0';
-		$expected->dimension2_id = '0';
-		$expected->inactive = '0';
+        $expected = new stdClass();
+        $expected->supplier_id = '1';
+        $expected->supp_name = 'supp_name';
+        $expected->supp_ref = 'supp_ref';
+        $expected->address = 'address';
+        $expected->supp_address = 'supp_address';
+        $expected->gst_no = 'gst_no';
+        $expected->website = 'website';
+        $expected->supp_account_no = 'supp_account_no';
+        $expected->bank_account = 'bank_account';
+        $expected->credit_limit = '1000';
+        $expected->curr_code = 'USD';
+        $expected->payment_terms = '1';
+        $expected->payable_account = '1010';
+        $expected->purchase_account = '1020';
+        $expected->payment_discount_account = '1030';
+        $expected->notes = 'notes';
+        $expected->tax_group_id = '1';
+        $expected->tax_included = '1';
+        $expected->contact = '';
+        $expected->dimension_id = '0';
+        $expected->dimension2_id = '0';
+        $expected->inactive = '0';
 
-		$expected->{ '0' } = '1';
-		$expected->{ '1' } = 'supp_name';
-		$expected->{ '2' }  = 'supp_ref';
-		$expected->{ '3' }  = 'address';
-		$expected->{ '4' }  = 'supp_address';
-		$expected->{ '5' }  = 'gst_no';
-		$expected->{ '6' }  = '';
-		$expected->{ '7' }  = 'supp_account_no';
-		$expected->{ '8' }  = 'website';
-		$expected->{ '9' }  = 'bank_account';
-		$expected->{ '10' }  = 'USD';
-		$expected->{ '11' }  = '1';
-		$expected->{ '12' }  = '1';
-		$expected->{ '13' }  = '0';
-		$expected->{ '14' }  = '0';
-		$expected->{ '15' }  = '1';
-		$expected->{ '16' }  = '1000';
-		$expected->{ '17' }  = '1020';
-		$expected->{ '18' }  = '1010';
-		$expected->{ '19' }  = '1030';
-		$expected->{ '20' }  = 'notes';
-		$expected->{ '21' }  = '0';
+        $expected->{ '0' } = '1';
+        $expected->{ '1' } = 'supp_name';
+        $expected->{ '2' }  = 'supp_ref';
+        $expected->{ '3' }  = 'address';
+        $expected->{ '4' }  = 'supp_address';
+        $expected->{ '5' }  = 'gst_no';
+        $expected->{ '6' }  = '';
+        $expected->{ '7' }  = 'supp_account_no';
+        $expected->{ '8' }  = 'website';
+        $expected->{ '9' }  = 'bank_account';
+        $expected->{ '10' }  = 'USD';
+        $expected->{ '11' }  = '1';
+        $expected->{ '12' }  = '1';
+        $expected->{ '13' }  = '0';
+        $expected->{ '14' }  = '0';
+        $expected->{ '15' }  = '1';
+        $expected->{ '16' }  = '1000';
+        $expected->{ '17' }  = '1020';
+        $expected->{ '18' }  = '1010';
+        $expected->{ '19' }  = '1030';
+        $expected->{ '20' }  = 'notes';
+        $expected->{ '21' }  = '0';
 
-		$this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $result);
 
-		// List again
-		$response = $client->get('/modules/api/suppliers/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // List again
+        $response = $client->get('/modules/api/suppliers/', array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
+        $count1 = count($result);
+        $this->assertEquals($count0 + 1, $count1);
 
-		// Get by id
-		$response = $client->get('/modules/api/suppliers/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // Get by id
+        $response = $client->get('/modules/api/suppliers/' . $id, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $result);
 
-		// Write back
-		$response = $client->put('/modules/api/suppliers/' . $id, array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'supp_name' => 'new supp_name',
-				'supp_ref' => 'new supp_ref',
-				'address' => 'new address',
-				'supp_address' => 'new supp_address',
-				'gst_no' => 'new gst_no',
-				'website' => 'new website',
-				'supp_account_no' => 'new supp_account_no',
-				'bank_account' => 'new bank_account',
-				'credit_limit' => '2000',
-				'curr_code' => 'NZD',
-				'payment_terms' => '2',
-				'payable_account' => '2010',
-				'purchase_account' => '2020',
-				'payment_discount_account' => '2030',
-				'notes' => 'new notes',
-				'tax_group_id' => '2',
-				'tax_included' => '2'
-			)
-		));
+        // Write back
+        $response = $client->put('/modules/api/suppliers/' . $id, array(
+            'headers' => TestEnvironment::headers(),
+            'form_params' => array(
+                'supp_name' => 'new supp_name',
+                'supp_ref' => 'new supp_ref',
+                'address' => 'new address',
+                'supp_address' => 'new supp_address',
+                'gst_no' => 'new gst_no',
+                'website' => 'new website',
+                'supp_account_no' => 'new supp_account_no',
+                'bank_account' => 'new bank_account',
+                'credit_limit' => '2000',
+                'curr_code' => 'NZD',
+                'payment_terms' => '2',
+                'payable_account' => '2010',
+                'purchase_account' => '2020',
+                'payment_discount_account' => '2030',
+                'notes' => 'new notes',
+                'tax_group_id' => '2',
+                'tax_included' => '2'
+            )
+        ));
 
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		// Get by id to read back
-		$response = $client->get('/modules/api/suppliers/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // Get by id to read back
+        $response = $client->get('/modules/api/suppliers/' . $id, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$expected->supp_name = 'new supp_name';
-		$expected->supp_ref = 'new supp_ref';
-		$expected->address = 'new address';
-		$expected->supp_address = 'new supp_address';
-		$expected->gst_no = 'new gst_no';
-		$expected->website = 'new website';
-		$expected->supp_account_no = 'new supp_account_no';
-		$expected->bank_account = 'new bank_account';
-		$expected->credit_limit = '2000';
-		$expected->curr_code = 'NZD';
-		$expected->payment_terms = '2';
-		$expected->payable_account = '2010';
-		$expected->purchase_account = '2020';
-		$expected->payment_discount_account = '2030';
-		$expected->notes = 'new notes';
-		$expected->tax_group_id = '2';
-		$expected->tax_included = '2';
-		$expected->contact = '';
-		$expected->dimension_id = '0';
-		$expected->dimension2_id = '0';
-		$expected->inactive = '0';
+        $expected->supp_name = 'new supp_name';
+        $expected->supp_ref = 'new supp_ref';
+        $expected->address = 'new address';
+        $expected->supp_address = 'new supp_address';
+        $expected->gst_no = 'new gst_no';
+        $expected->website = 'new website';
+        $expected->supp_account_no = 'new supp_account_no';
+        $expected->bank_account = 'new bank_account';
+        $expected->credit_limit = '2000';
+        $expected->curr_code = 'NZD';
+        $expected->payment_terms = '2';
+        $expected->payable_account = '2010';
+        $expected->purchase_account = '2020';
+        $expected->payment_discount_account = '2030';
+        $expected->notes = 'new notes';
+        $expected->tax_group_id = '2';
+        $expected->tax_included = '2';
+        $expected->contact = '';
+        $expected->dimension_id = '0';
+        $expected->dimension2_id = '0';
+        $expected->inactive = '0';
 
-		$expected->{ '0' } = '1';
-		$expected->{ '1' } = 'new supp_name';
-		$expected->{ '2' }  = 'new supp_ref';
-		$expected->{ '3' }  = 'new address';
-		$expected->{ '4' }  = 'new supp_address';
-		$expected->{ '5' }  = 'new gst_no';
-		$expected->{ '6' }  = '';
-		$expected->{ '7' }  = 'new supp_account_no';
-		$expected->{ '8' }  = 'new website';
-		$expected->{ '9' }  = 'new bank_account';
-		$expected->{ '10' }  = 'NZD';
-		$expected->{ '11' }  = '2';
-		$expected->{ '12' }  = '2';
-		$expected->{ '13' }  = '0';
-		$expected->{ '14' }  = '0';
-		$expected->{ '15' }  = '2';
-		$expected->{ '16' }  = '2000';
-		$expected->{ '17' }  = '2020';
-		$expected->{ '18' }  = '2010';
-		$expected->{ '19' }  = '2030';
-		$expected->{ '20' }  = 'new notes';
-		$expected->{ '21' }  = '0';
+        $expected->{ '0' } = '1';
+        $expected->{ '1' } = 'new supp_name';
+        $expected->{ '2' }  = 'new supp_ref';
+        $expected->{ '3' }  = 'new address';
+        $expected->{ '4' }  = 'new supp_address';
+        $expected->{ '5' }  = 'new gst_no';
+        $expected->{ '6' }  = '';
+        $expected->{ '7' }  = 'new supp_account_no';
+        $expected->{ '8' }  = 'new website';
+        $expected->{ '9' }  = 'new bank_account';
+        $expected->{ '10' }  = 'NZD';
+        $expected->{ '11' }  = '2';
+        $expected->{ '12' }  = '2';
+        $expected->{ '13' }  = '0';
+        $expected->{ '14' }  = '0';
+        $expected->{ '15' }  = '2';
+        $expected->{ '16' }  = '2000';
+        $expected->{ '17' }  = '2020';
+        $expected->{ '18' }  = '2010';
+        $expected->{ '19' }  = '2030';
+        $expected->{ '20' }  = 'new notes';
+        $expected->{ '21' }  = '0';
 
-		$this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $result);
 
-		// List again
-		$response = $client->get('/modules/api/suppliers/', array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // List again
+        $response = $client->get('/modules/api/suppliers/', array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$count1 = count($result);
-		$this->assertEquals($count0 + 1, $count1);
+        $count1 = count($result);
+        $this->assertEquals($count0 + 1, $count1);
 
-		$this->assertEquals($id, $result[$count1 - 1]->supplier_id);
+        $this->assertEquals($id, $result[$count1 - 1]->supplier_id);
 
-		// Delete
-		$response = $client->delete('/modules/api/suppliers/' . $id, array(
-			'headers' => TestEnvironment::headers()
-		));
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        // Delete
+        $response = $client->delete('/modules/api/suppliers/' . $id, array(
+            'headers' => TestEnvironment::headers()
+        ));
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		// List again
-		$response = $client->get('/modules/api/suppliers/', array(
-			'headers' => TestEnvironment::headers()
-		));
+        // List again
+        $response = $client->get('/modules/api/suppliers/', array(
+            'headers' => TestEnvironment::headers()
+        ));
 
-		$this->assertEquals('200', $response->getStatusCode());
-		$result = $response->getBody();
-		$result = json_decode($result);
+        $this->assertEquals('200', $response->getStatusCode());
+        $result = $response->getBody();
+        $result = json_decode($result);
 
-		$count2 = count($result);
-		$this->assertEquals($count0, $count2);
+        $count2 = count($result);
+        $this->assertEquals($count0, $count2);
 
-	}
+    }
 */
 }

--- a/tests/Tax_Test.php
+++ b/tests/Tax_Test.php
@@ -8,7 +8,6 @@ require_once(TEST_PATH . '/TestEnvironment.php');
 
 class TaxTest extends PHPUnit_Framework_TestCase
 {
-
     public function testTaxTypes_Ok()
     {
         $client = TestEnvironment::client();

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -3,9 +3,9 @@
 ini_set('xdebug.show_exception_trace', 0);
 
 if (file_exists(__DIR__ . '/../_frontaccounting')) {
-	$rootPath = realpath(__DIR__ . '/../_frontaccounting');
+    $rootPath = realpath(__DIR__ . '/../_frontaccounting');
 } else {
-	$rootPath = realpath(__DIR__ . '/../../..');
+    $rootPath = realpath(__DIR__ . '/../../..');
 }
 
 $apiPath = $rootPath . '/modules/api';
@@ -13,4 +13,3 @@ define('ROOT_PATH', $rootPath);
 define('SRC_PATH', $rootPath);
 define('API_PATH', $apiPath);
 define('TEST_PATH', $apiPath . '/tests');
-

--- a/tests/TestEnvironment.php
+++ b/tests/TestEnvironment.php
@@ -1,203 +1,204 @@
 <?php
 use GuzzleHttp\Client;
-require_once (__DIR__ . '/TestConfig.php');
+
+require_once(__DIR__ . '/TestConfig.php');
 
 class TestEnvironment
 {
 
-	/**
-	 *
-	 * @return \GuzzleHttp\Client
-	 */
-	public static function client()
-	{
-		return new Client(array(
-			'base_uri' => 'http://localhost:8000'
-		), array(
-			'request.options' => array(
-				'exceptions' => false
-			)
-		));
-	}
+    /**
+     *
+     * @return \GuzzleHttp\Client
+     */
+    public static function client()
+    {
+        return new Client(array(
+            'base_uri' => 'http://localhost:8000'
+        ), array(
+            'request.options' => array(
+                'exceptions' => false
+            )
+        ));
+    }
 
-	public static function createCustomer($client, $ref, $name)
-	{
-		$response = $client->post('/modules/api/customers/', array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'name' => $name,
-				'debtor_ref' => $ref,
-				'address' => 'address',
-				'tax_id' => 'tax_id',
-				'curr_code' => 'USD',
-				'credit_status' => '1',
-				'payment_terms' => '1',
-				'discount' => '0',
-				'pymt_discount' => '0',
-				'credit_limit' => '1000',
-				'sales_type' => '1',
-				'notes' => 'notes'
-			)
-		));
-		$result = $response->getStatusCode();
-		if ($result != 201) {
-			throw new \Exception('Create customer failed', $result);
-		}
-	}
+    public static function createCustomer($client, $ref, $name)
+    {
+        $response = $client->post('/modules/api/customers/', array(
+            'headers' => TestEnvironment::headers(),
+            'form_params' => array(
+                'name' => $name,
+                'debtor_ref' => $ref,
+                'address' => 'address',
+                'tax_id' => 'tax_id',
+                'curr_code' => 'USD',
+                'credit_status' => '1',
+                'payment_terms' => '1',
+                'discount' => '0',
+                'pymt_discount' => '0',
+                'credit_limit' => '1000',
+                'sales_type' => '1',
+                'notes' => 'notes'
+            )
+        ));
+        $result = $response->getStatusCode();
+        if ($result != 201) {
+            throw new \Exception('Create customer failed', $result);
+        }
+    }
 
-	public static function createItem($client, $id, $description)
-	{
-		$response = $client->post('/modules/api/inventory/', array(
-			'headers' => TestEnvironment::headers(),
-			'form_params' => array(
-				'stock_id' => $id,
-				'description' => $description,
-				'long_description' => $description,
-				'category_id' => '1',
-				'tax_type_id' => '1',
-				'units' => 'ea',
-				'mb_flag' => '0',
-				'sales_account' => '1',
-				'inventory_account' => '1',
-				'cogs_account' => '1',
-				'adjustment_account' => '1',
-				'wip_account' => '1'
-			)
-		));
+    public static function createItem($client, $id, $description)
+    {
+        $response = $client->post('/modules/api/inventory/', array(
+            'headers' => TestEnvironment::headers(),
+            'form_params' => array(
+                'stock_id' => $id,
+                'description' => $description,
+                'long_description' => $description,
+                'category_id' => '1',
+                'tax_type_id' => '1',
+                'units' => 'ea',
+                'mb_flag' => '0',
+                'sales_account' => '1',
+                'inventory_account' => '1',
+                'cogs_account' => '1',
+                'adjustment_account' => '1',
+                'wip_account' => '1'
+            )
+        ));
 
-		$result = $response->getStatusCode();
-		if ($result != 201) {
-			throw new \Exception('Create item failed', $result);
-		}
-	}
+        $result = $response->getStatusCode();
+        if ($result != 201) {
+            throw new \Exception('Create item failed', $result);
+        }
+    }
 
-	public static function createId()
-	{
-		return date('YmdHis');
-	}
+    public static function createId()
+    {
+        return date('YmdHis');
+    }
 
-	/**
-	 * Return the X-COMPANY, X-USER, and X-PASSWORD headers
-	 *
-	 * @return multitype:string
-	 */
-	public static function headers()
-	{
-		return array(
-			'X-COMPANY' => '0',
-			'X-USER' => 'test',
-			'X-PASSWORD' => 'test'
-		);
-	}
+    /**
+     * Return the X-COMPANY, X-USER, and X-PASSWORD headers
+     *
+     * @return multitype:string
+     */
+    public static function headers()
+    {
+        return array(
+            'X-COMPANY' => '0',
+            'X-USER' => 'test',
+            'X-PASSWORD' => 'test'
+        );
+    }
 
-	private static function setupErrorReporting()
-	{
-		$GLOBALS['messages'] = array();
-	}
+    private static function setupErrorReporting()
+    {
+        $GLOBALS['messages'] = array();
+    }
 
-	private static function resetErrorReporting()
-	{
-		// Undo that which is setup in config.php (of all places)
-		error_reporting(- 1);
-	}
+    private static function resetErrorReporting()
+    {
+        // Undo that which is setup in config.php (of all places)
+        error_reporting(- 1);
+    }
 
-	private static function setupAPI()
-	{
-		global $Ajax, $Validate, $Editors, $Pagehelp, $Refs;
+    private static function setupAPI()
+    {
+        global $Ajax, $Validate, $Editors, $Pagehelp, $Refs;
 
-		$_SERVER['REMOTE_ADDR'] = 'phpunit';
+        $_SERVER['REMOTE_ADDR'] = 'phpunit';
 
-		self::includeFile('includes/ajax.inc');
-		// Ajax communication object
-		$Ajax = new Ajax();
+        self::includeFile('includes/ajax.inc');
+        // Ajax communication object
+        $Ajax = new Ajax();
 
-		// js/php validation rules container
-		$Validate = array();
-		// bindings for editors
-		$Editors = array();
-		// page help. Currently help for function keys.
-		$Pagehelp = array();
+        // js/php validation rules container
+        $Validate = array();
+        // bindings for editors
+        $Editors = array();
+        // page help. Currently help for function keys.
+        $Pagehelp = array();
 
-		self::mockRefs();
-	}
+        self::mockRefs();
+    }
 
-	private static function setupSQL()
-	{
-		global $db, $show_sql, $sql_trail, $select_trail, $go_debug, $sql_queries, $Ajax, $db_connections, $db_last_inserted_id;
-		self::includeFile('config_db.php');
-		self::includeFile('includes/db/connect_db.inc');
-		self::includeFile('includes/db/sql_functions.inc');
-		self::includeFile('includes/errors.inc');
-		set_global_connection();
-	}
+    private static function setupSQL()
+    {
+        global $db, $show_sql, $sql_trail, $select_trail, $go_debug, $sql_queries, $Ajax, $db_connections, $db_last_inserted_id;
+        self::includeFile('config_db.php');
+        self::includeFile('includes/db/connect_db.inc');
+        self::includeFile('includes/db/sql_functions.inc');
+        self::includeFile('includes/errors.inc');
+        set_global_connection();
+    }
 
-	private static function setupSQLDependencies()
-	{
-		self::includeFile('includes/hooks.inc');
-		self::includeFile('includes/types.inc');
-		self::includeFile('includes/systypes.inc');
-		self::includeFile('includes/prefs/sysprefs.inc');
-		self::includeFile('includes/db/comments_db.inc');
-		self::includeFile('includes/db/audit_trail_db.inc');
-		$_SESSION['SysPrefs'] = null;
-		$GLOBALS['SysPrefs'] = &$_SESSION['SysPrefs'];
-		self::mockRefs();
-	}
+    private static function setupSQLDependencies()
+    {
+        self::includeFile('includes/hooks.inc');
+        self::includeFile('includes/types.inc');
+        self::includeFile('includes/systypes.inc');
+        self::includeFile('includes/prefs/sysprefs.inc');
+        self::includeFile('includes/db/comments_db.inc');
+        self::includeFile('includes/db/audit_trail_db.inc');
+        $_SESSION['SysPrefs'] = null;
+        $GLOBALS['SysPrefs'] = &$_SESSION['SysPrefs'];
+        self::mockRefs();
+    }
 
-	private static function setupSesstion()
-	{
-		$_SESSION["wa_current_user"] = new TestUser();
-	}
+    private static function setupSesstion()
+    {
+        $_SESSION["wa_current_user"] = new TestUser();
+    }
 
-	private static function mockRefs()
-	{
-		$GLOBALS['Refs'] = new MockRefs();
-	}
+    private static function mockRefs()
+    {
+        $GLOBALS['Refs'] = new MockRefs();
+    }
 
-	public static function isGoodToGo()
-	{
-		global $db_connections;
-		self::setupErrorReporting();
-		self::setupAPI();
-		// self::resetErrorReporting();
-		self::setupSesstion();
-		self::setupSQL();
-		self::setupSQLDependencies();
-		$msg = '';
-		$dbname = $db_connections[0]['dbname'];
-		$expected = 'fa_test';
-		if ($dbname != $expected) {
-			$msg .= "Error: Wrong database '$dbname' expected '$expected'";
-		}
-		return ($msg == '') ? 'OK' : $msg;
-	}
+    public static function isGoodToGo()
+    {
+        global $db_connections;
+        self::setupErrorReporting();
+        self::setupAPI();
+        // self::resetErrorReporting();
+        self::setupSesstion();
+        self::setupSQL();
+        self::setupSQLDependencies();
+        $msg = '';
+        $dbname = $db_connections[0]['dbname'];
+        $expected = 'fa_test';
+        if ($dbname != $expected) {
+            $msg .= "Error: Wrong database '$dbname' expected '$expected'";
+        }
+        return ($msg == '') ? 'OK' : $msg;
+    }
 
-	public static function includeFile($filePath)
-	{
-		$path_to_root = SRC_PATH;
-		require_once (SRC_PATH . '/' . $filePath);
-	}
+    public static function includeFile($filePath)
+    {
+        $path_to_root = SRC_PATH;
+        require_once(SRC_PATH . '/' . $filePath);
+    }
 
-	public static function currentAccount()
-	{
-		return 1;
-	}
+    public static function currentAccount()
+    {
+        return 1;
+    }
 
-	public static function cashAccount()
-	{
-		return 2;
-	}
+    public static function cashAccount()
+    {
+        return 2;
+    }
 
-	public static function cleanTable($table)
-	{
-		$sql = 'DELETE FROM ' . '0_' . $table;
-		db_query($sql, "Could not clean table '$table'");
-	}
+    public static function cleanTable($table)
+    {
+        $sql = 'DELETE FROM ' . '0_' . $table;
+        db_query($sql, "Could not clean table '$table'");
+    }
 
-	public static function cleanBanking()
-	{
-		self::cleanTable('bank_trans');
-		self::cleanTable('gl_trans');
-		self::cleanTable('comments');
-	}
+    public static function cleanBanking()
+    {
+        self::cleanTable('bank_trans');
+        self::cleanTable('gl_trans');
+        self::cleanTable('comments');
+    }
 }

--- a/util.php
+++ b/util.php
@@ -31,22 +31,23 @@ function api_response($code, $body)
 {
 	$app = \Slim\Slim::getInstance('SASYS');
 	$app->response()->status($code);
+	if (is_array($body)) {
+		$body= json_encode($body);
+	}
 	$app->response()->body($body);
 }
 
 function api_success_response($body)
 {
 	$app = \Slim\Slim::getInstance('SASYS');
-	$app->response()->status(200);
-	$app->response()->body($body);
+	api_response(200, $body);
 	//$app->response()->['Content-Type'] = $content_type;
 }
 
 function api_create_response($body)
 {
 	$app = \Slim\Slim::getInstance('SASYS');
-	$app->response()->status(201);
-	$app->response()->body($body);
+	api_response(201, $body);
 	//$app->response()->['Content-Type'] = $content_type;
 }
 
@@ -70,4 +71,40 @@ function api_ensureAssociativeArray($a)
 		}
 	}
 	return $a;
+}
+
+function api_validate_required($property, $model) {
+	if (!isset($model[$property])) {
+		return false;
+	}
+	return true;
+}
+
+function api_validate_message($test, $property) {
+	$messages = array(
+		"api_validate_required" => "Missing a required proprty '$property'"
+	);
+	if (isset($messages[$test])) {
+		return $messages[$test];
+	}
+	return '';
+}
+
+function api_validate($property, $model, $code = 412, $test = 'api_validate_required', $msg = null) {
+	if ($test($property, $model)) {
+		return;
+	}
+	if (!$msg) {
+		$msg = \api_validate_message($test, $property);
+		if (!$msg) {
+			$msg = "Unknown error in '$property'";
+		}
+	}
+	\api_error($code, $msg);
+}
+
+function api_check($property, &$model, $default = '') {
+	if (!isset($model[$property])) {
+		$model[$property] = $default;
+	}
 }

--- a/util.php
+++ b/util.php
@@ -104,8 +104,19 @@ function api_validate($property, $model, $code = 412, $test = 'api_validate_requ
     \api_error($code, $msg);
 }
 
-function api_check($property, &$model, $default = '') {
+/**
+ * @param string $property
+ * @param array $model
+ * @param string|array $default
+ */
+function api_check($property, &$model, $default = '')
+{
     if (!isset($model[$property])) {
+        if (is_array($default)) {
+            if (array_key_exists($property, $default)) {
+                $default = $default[$property];
+            }
+        }
         $model[$property] = $default;
     }
 }

--- a/util.php
+++ b/util.php
@@ -7,104 +7,105 @@ Free software under GNU GPL
 
 function api_login()
 {
-	$app = \Slim\Slim::getInstance('SASYS');
-	$app->hook('slim.before', function () use ($app) {
-		$req = $app->request();
-		$company = $req->headers('X-COMPANY');
-		$user = $req->headers('X-USER');
-		$password = $req->headers('X-PASSWORD');
+    $app = \Slim\Slim::getInstance('SASYS');
+    $app->hook('slim.before', function () use ($app) {
+        $req = $app->request();
+        $company = $req->headers('X-COMPANY');
+        $user = $req->headers('X-USER');
+        $password = $req->headers('X-PASSWORD');
 
-		// TESTING
-		/*$company = 0;
-		$user = 'admin';
-		$password = '123';*/
+        // TESTING
+        /*$company = 0;
+        $user = 'admin';
+        $password = '123';*/
 
-		$succeed = $_SESSION["wa_current_user"]->login($company,
-					$user, $password);
-		if (!$succeed) {
-			$app->halt(403, 'Bad Login For Company: ' . $company . ' With User: ' . $user);
-		}
-	}, 1);
+        $succeed = $_SESSION["wa_current_user"]->login(
+            $company, $user, $password
+        );
+        if (!$succeed) {
+            $app->halt(403, 'Bad Login For Company: ' . $company . ' With User: ' . $user);
+        }
+    }, 1);
 }
 
 function api_response($code, $body)
 {
-	$app = \Slim\Slim::getInstance('SASYS');
-	$app->response()->status($code);
-	if (is_array($body)) {
-		$body= json_encode($body);
-	}
-	$app->response()->body($body);
+    $app = \Slim\Slim::getInstance('SASYS');
+    $app->response()->status($code);
+    if (is_array($body)) {
+        $body= json_encode($body);
+    }
+    $app->response()->body($body);
 }
 
 function api_success_response($body)
 {
-	$app = \Slim\Slim::getInstance('SASYS');
-	api_response(200, $body);
-	//$app->response()->['Content-Type'] = $content_type;
+    $app = \Slim\Slim::getInstance('SASYS');
+    api_response(200, $body);
+    //$app->response()->['Content-Type'] = $content_type;
 }
 
 function api_create_response($body)
 {
-	$app = \Slim\Slim::getInstance('SASYS');
-	api_response(201, $body);
-	//$app->response()->['Content-Type'] = $content_type;
+    $app = \Slim\Slim::getInstance('SASYS');
+    api_response(201, $body);
+    //$app->response()->['Content-Type'] = $content_type;
 }
 
 function api_error($code, $msg)
 {
-	$app = \Slim\Slim::getInstance('SASYS');
-	$app->halt($code, json_encode(array('success' => 0, 'msg' => $msg)));
+    $app = \Slim\Slim::getInstance('SASYS');
+    $app->halt($code, json_encode(array('code' => $code, 'success' => 0, 'msg' => $msg)));
 }
 
 function api_ensureAssociativeArray($a)
 {
-	if (!$a)
-	{
-		$a = array();
-	}
-	foreach ($a as $key => $value)
-	{
-		if (is_int($key))
-		{
-			unset($a[$key]);
-		}
-	}
-	return $a;
+    if (!$a) {
+        $a = array();
+    }
+    foreach ($a as $key => $value) {
+        if (is_int($key)) {
+            unset($a[$key]);
+        }
+    }
+    return $a;
 }
 
-function api_validate_required($property, $model) {
-	if (!isset($model[$property])) {
-		return false;
-	}
-	return true;
+function api_validate_required($property, $model)
+{
+    if (!isset($model[$property])) {
+        return false;
+    }
+    return true;
 }
 
-function api_validate_message($test, $property) {
-	$messages = array(
-		"api_validate_required" => "Missing a required proprty '$property'"
-	);
-	if (isset($messages[$test])) {
-		return $messages[$test];
-	}
-	return '';
+function api_validate_message($test, $property)
+{
+    $messages = array(
+        "api_validate_required" => "Missing a required proprty '$property'"
+    );
+    if (isset($messages[$test])) {
+        return $messages[$test];
+    }
+    return '';
 }
 
-function api_validate($property, $model, $code = 412, $test = 'api_validate_required', $msg = null) {
-	if ($test($property, $model)) {
-		return;
-	}
-	if (!$msg) {
-		$msg = \api_validate_message($test, $property);
-		if (!$msg) {
-			$msg = "Unknown error in '$property'";
-		}
-	}
-	\api_error($code, $msg);
+function api_validate($property, $model, $code = 412, $test = 'api_validate_required', $msg = null)
+{
+    if ($test($property, $model)) {
+        return;
+    }
+    if (!$msg) {
+        $msg = \api_validate_message($test, $property);
+        if (!$msg) {
+            $msg = "Unknown error in '$property'";
+        }
+    }
+    \api_error($code, $msg);
 }
 
 function api_check($property, &$model, $default = '') {
-	if (!isset($model[$property])) {
-		$model[$property] = $default;
-	}
+    if (!isset($model[$property])) {
+        $model[$property] = $default;
+    }
 }


### PR DESCRIPTION
GLAccounts: Add full CRUD to glaccounts end point

- Add post
- Add put
- Add delete
- Fix list which was only returning 2 accounts due to paging
- Add CRUD tests for glaccounts end point
- Remove id check from Crud_Base which incorrectly assumed the added item would be the last in the list.

Dimensions: Add CRUD for dimensions

- Also refactor tests/CrudBase in which getData was not used.
- Added documentation for /dimensions api

Produce static api documentation using swagger and spectacle.  A sample is provided.  The documentation is far from complete.

- Add build tasks to generate swagger.json from annotated source
- Add build tasks to generate static api docs from swagger.json

The generated docs are available [here](http://cambell-prince.github.io/FrontAccountingSimpleAPI/)

Reformatted the code under src/ and test/ to PSR-2 standard and added a note to README.md

Bank Accounts: Add full CRUD for Bank Accounts under the bankaccounts endpoint.