### PR TITLE
docs: Update api docs link in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+#### 23 June 2018
+
+- Change README.md API documentation to point to http://andresamayadiaz.github.io/FrontAccountingSimpleAPI/
+
 #### 22 June 2018
 
 - Add full CRUD for Journal entry, update, and delete (void).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ I needed some basic integration functions to another software and decided to cre
 
 ## Documentation
 
-See the [API Documentation](http://cambell-prince.github.io/FrontAccountingSimpleAPI/) for descriptions of each endpoint.
+See the [API Documentation](http://andresamayadiaz.github.io/FrontAccountingSimpleAPI/) for descriptions of each endpoint.
 
 ### Methods
 


### PR DESCRIPTION
Now that the api docs exist on https://andresamayadiaz.github.io/FrontAccountingSimpleAPI/ fix the README.md to match.  I've also put in a redirect from https://cambell-prince.github.io/FrontAccountingSimpleAPI/ also.